### PR TITLE
Feature/18 add refresh token flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,4 +10,5 @@ SPRING_JPA_DDL_AUTO=validate
 
 # JWT — generate with: openssl rand -base64 32
 JWT_SECRET=your-base64-encoded-secret-here
-# JWT_EXPIRATION=86400000  # optional, default 24h in ms
+# JWT_EXPIRATION=7200000  # optional, default 2h in ms
+# JWT_EXPIRATION=172800000  # optional, default 48h in ms

--- a/src/main/java/com/caffeine/acs_backend/controller/AuthController.java
+++ b/src/main/java/com/caffeine/acs_backend/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.caffeine.acs_backend.controller;
 import com.caffeine.acs_backend.dto.auth.AuthResponse;
 import com.caffeine.acs_backend.dto.auth.LoginRequest;
 import com.caffeine.acs_backend.dto.auth.RegisterRequest;
+import com.caffeine.acs_backend.dto.auth.RefreshRequest;
 import com.caffeine.acs_backend.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -36,11 +37,21 @@ public class AuthController {
 
   @Operation(
       summary = "Authenticate user",
-      description = "Authenticates a user with email and password and returns a JWT token.")
+      description = "Authenticates a user with email and password and returns access and refresh JWT tokens.")
   @ApiResponse(responseCode = "200", description = "User authenticated successfully")
   @ApiResponse(responseCode = "401", description = "Invalid credentials")
   @PostMapping("/login")
   public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
     return ResponseEntity.ok(authService.login(request));
+  }
+
+  @Operation(
+      summary = "Refresh JWT access token",
+      description = "Refreshes JWT access token if refresh token is valid.")
+  @ApiResponse(responseCode = "200", description = "JWT access token is refreshed")
+  @ApiResponse(responseCode = "401", description = "Invalid JWT refresh token")
+  @PostMapping("/refresh")
+  public ResponseEntity<AuthResponse> refresh(@Valid @RequestBody RefreshRequest refreshToken) {
+    return ResponseEntity.ok(authService.refresh(refreshToken.refreshToken()));
   }
 }

--- a/src/main/java/com/caffeine/acs_backend/controller/AuthController.java
+++ b/src/main/java/com/caffeine/acs_backend/controller/AuthController.java
@@ -2,8 +2,8 @@ package com.caffeine.acs_backend.controller;
 
 import com.caffeine.acs_backend.dto.auth.AuthResponse;
 import com.caffeine.acs_backend.dto.auth.LoginRequest;
-import com.caffeine.acs_backend.dto.auth.RegisterRequest;
 import com.caffeine.acs_backend.dto.auth.RefreshRequest;
+import com.caffeine.acs_backend.dto.auth.RegisterRequest;
 import com.caffeine.acs_backend.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -37,7 +37,8 @@ public class AuthController {
 
   @Operation(
       summary = "Authenticate user",
-      description = "Authenticates a user with email and password and returns access and refresh JWT tokens.")
+      description =
+          "Authenticates a user with email and password and returns access and refresh JWT tokens.")
   @ApiResponse(responseCode = "200", description = "User authenticated successfully")
   @ApiResponse(responseCode = "401", description = "Invalid credentials")
   @PostMapping("/login")

--- a/src/main/java/com/caffeine/acs_backend/dto/auth/AuthResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/auth/AuthResponse.java
@@ -5,4 +5,5 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "Authentication response containing JWT token and user info")
 public record AuthResponse(
     @Schema(description = "JWT access token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
-        String accessToken, String refreshToken) {}
+        String accessToken,
+    String refreshToken) {}

--- a/src/main/java/com/caffeine/acs_backend/dto/auth/AuthResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/auth/AuthResponse.java
@@ -5,4 +5,4 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "Authentication response containing JWT token and user info")
 public record AuthResponse(
     @Schema(description = "JWT access token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
-        String token) {}
+        String accessToken, String refreshToken) {}

--- a/src/main/java/com/caffeine/acs_backend/dto/auth/RefreshRequest.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/auth/RefreshRequest.java
@@ -1,0 +1,8 @@
+package com.caffeine.acs_backend.dto.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "JWT token refresh")
+public record RefreshRequest(
+    @Schema(description = "JWT refresh token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+        String refreshToken) {}

--- a/src/main/java/com/caffeine/acs_backend/security/JwtService.java
+++ b/src/main/java/com/caffeine/acs_backend/security/JwtService.java
@@ -20,6 +20,9 @@ public class JwtService {
   @Value("${jwt.expiration}")
   private long expirationMs;
 
+  @Value("${jwt.refresh-expiration}")
+  private long refreshExpirationMs;
+
   private SecretKey signingKey;
 
   @PostConstruct
@@ -27,11 +30,20 @@ public class JwtService {
     this.signingKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
   }
 
-  public String generateToken(UserDetails userDetails) {
+  public String generateAccessToken(UserDetails userDetails) {
+    return buildToken(userDetails, expirationMs, "access");
+  }
+
+  public String generateRefreshToken(UserDetails userDetails) {
+    return buildToken(userDetails, refreshExpirationMs, "refresh");
+  }
+
+  private String buildToken(UserDetails userDetails, long expiration, String type) {
     return Jwts.builder()
         .subject(userDetails.getUsername())
+        .claim("type", type)
         .issuedAt(new Date())
-        .expiration(new Date(System.currentTimeMillis() + expirationMs))
+        .expiration(new Date(System.currentTimeMillis() + expiration))
         .signWith(signingKey)
         .compact();
   }

--- a/src/main/java/com/caffeine/acs_backend/service/AuthService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/AuthService.java
@@ -7,8 +7,8 @@ import com.caffeine.acs_backend.entity.User;
 import com.caffeine.acs_backend.enums.UserRole;
 import com.caffeine.acs_backend.repository.UserRepository;
 import com.caffeine.acs_backend.security.JwtService;
-import lombok.RequiredArgsConstructor;
 import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -67,8 +67,10 @@ public class AuthService {
 
     String email = claims.getSubject();
 
-    User user = userRepository.findByEmail(email)
-        .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED));
+    User user =
+        userRepository
+            .findByEmail(email)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED));
 
     if (!jwtService.isTokenValid(refreshToken, user)) {
       throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token");

--- a/src/main/java/com/caffeine/acs_backend/service/AuthService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/AuthService.java
@@ -8,6 +8,7 @@ import com.caffeine.acs_backend.enums.UserRole;
 import com.caffeine.acs_backend.repository.UserRepository;
 import com.caffeine.acs_backend.security.JwtService;
 import lombok.RequiredArgsConstructor;
+import io.jsonwebtoken.Claims;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -37,7 +38,11 @@ public class AuthService {
             .build();
 
     userRepository.save(user);
-    return new AuthResponse(jwtService.generateToken(user));
+
+    String accessToken = jwtService.generateAccessToken(user);
+    String refreshToken = jwtService.generateRefreshToken(user);
+
+    return new AuthResponse(accessToken, refreshToken);
   }
 
   public AuthResponse login(LoginRequest request) {
@@ -45,6 +50,32 @@ public class AuthService {
         new UsernamePasswordAuthenticationToken(request.email(), request.password()));
 
     User user = userRepository.findByEmail(request.email()).orElseThrow();
-    return new AuthResponse(jwtService.generateToken(user));
+
+    String accessToken = jwtService.generateAccessToken(user);
+    String refreshToken = jwtService.generateRefreshToken(user);
+
+    return new AuthResponse(accessToken, refreshToken);
+  }
+
+  public AuthResponse refresh(String refreshToken) {
+    Claims claims = jwtService.extractClaims(refreshToken);
+
+    String type = claims.get("type", String.class);
+    if (!"refresh".equals(type)) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token type");
+    }
+
+    String email = claims.getSubject();
+
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED));
+
+    if (!jwtService.isTokenValid(refreshToken, user)) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token");
+    }
+
+    String newAccessToken = jwtService.generateAccessToken(user);
+
+    return new AuthResponse(newAccessToken, refreshToken);
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,4 +15,5 @@ server.port=${SPRING_PORT:8080}
 
 # ===== JWT =====
 jwt.secret=${JWT_SECRET}
-jwt.expiration=${JWT_EXPIRATION:86400000}
+jwt.expiration=${JWT_EXPIRATION:7200000}
+jwt.refresh-expiration=${JWT_REFRESH_EXPIRATION:172800000}

--- a/src/test/java/com/caffeine/acs_backend/controller/AuthControllerTest.java
+++ b/src/test/java/com/caffeine/acs_backend/controller/AuthControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.caffeine.acs_backend.dto.auth.LoginRequest;
+import com.caffeine.acs_backend.dto.auth.RefreshRequest;
 import com.caffeine.acs_backend.dto.auth.RegisterRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.UUID;
@@ -40,7 +41,8 @@ class AuthControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.token").isNotEmpty());
+        .andExpect(jsonPath("$.accessToken").isNotEmpty())
+        .andExpect(jsonPath("$.refreshToken").isNotEmpty());
   }
 
   @Test
@@ -99,7 +101,8 @@ class AuthControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(loginRequest)))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.token").isNotEmpty());
+        .andExpect(jsonPath("$.accessToken").isNotEmpty())
+        .andExpect(jsonPath("$.refreshToken").isNotEmpty());
   }
 
   @Test
@@ -129,6 +132,64 @@ class AuthControllerTest {
         .andExpect(status().isUnauthorized());
   }
 
+// ── Refresh ─────────────────────────────────────────────────────────────────
+
+  @Test
+  void refresh_validRefreshToken_returns200WithNewAccessToken() throws Exception {
+      String email = uniqueEmail();
+      String[] tokens = registerUser(email, "password123");
+
+      var request = new RefreshRequest(tokens[1]);
+
+      mockMvc
+          .perform(
+              post("/api/auth/refresh")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.accessToken").isNotEmpty())
+          .andExpect(jsonPath("$.refreshToken").isNotEmpty());
+  }
+
+  @Test
+  void refresh_accessTokenInsteadOfRefresh_returns401() throws Exception {
+      String email = uniqueEmail();
+      String[] tokens = registerUser(email, "password123");
+
+      var request = new RefreshRequest(tokens[0]); // передаём access вместо refresh
+
+      mockMvc
+          .perform(
+              post("/api/auth/refresh")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void refresh_invalidToken_returns401() throws Exception {
+      var request = new RefreshRequest("invalid.token.here");
+
+      mockMvc
+          .perform(
+              post("/api/auth/refresh")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void refresh_blankToken_returns400() throws Exception {
+      var request = new RefreshRequest("");
+
+      mockMvc
+          .perform(
+              post("/api/auth/refresh")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isBadRequest());
+  }
+
   // ── Protected endpoints ─────────────────────────────────────────────────────
 
   @Test
@@ -139,10 +200,12 @@ class AuthControllerTest {
   @Test
   void protectedEndpoint_withValidToken_returns200() throws Exception {
     String email = uniqueEmail();
-    String token = registerUser(email, "password123");
+    String[] tokens = registerUser(email, "password123");
+    String accessToken = tokens[0];
+    String refreshToken = tokens[1];
 
     mockMvc
-        .perform(get("/api/users/me").header("Authorization", "Bearer " + token))
+        .perform(get("/api/users/me").header("Authorization", "Bearer " + accessToken))
         .andExpect(status().isOk());
   }
 
@@ -156,11 +219,13 @@ class AuthControllerTest {
   @Test
   void register_assignsVisitorRole() throws Exception {
     String email = uniqueEmail();
-    String token = registerUser(email, "password123");
+    String[] tokens = registerUser(email, "password123");
+    String accessToken = tokens[0];
+    String refreshToken = tokens[1];
 
     String responseBody =
         mockMvc
-            .perform(get("/api/users/me").header("Authorization", "Bearer " + token))
+            .perform(get("/api/users/me").header("Authorization", "Bearer " + accessToken))
             .andExpect(status().isOk())
             .andReturn()
             .getResponse()
@@ -184,19 +249,23 @@ class AuthControllerTest {
 
   // ── Helpers ─────────────────────────────────────────────────────────────────
 
-  private String registerUser(String email, String password) throws Exception {
-    var request = new RegisterRequest(email, password);
-    String responseBody =
-        mockMvc
-            .perform(
-                post("/api/auth/register")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request)))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
+  private String[] registerUser(String email, String password) throws Exception {
+      var request = new RegisterRequest(email, password);
+      String responseBody =
+          mockMvc
+              .perform(
+                  post("/api/auth/register")
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content(objectMapper.writeValueAsString(request)))
+              .andExpect(status().isOk())
+              .andReturn()
+              .getResponse()
+              .getContentAsString();
 
-    return objectMapper.readTree(responseBody).get("token").asText();
+      var tree = objectMapper.readTree(responseBody);
+      return new String[]{
+          tree.get("accessToken").asText(),
+          tree.get("refreshToken").asText()
+      };
   }
 }

--- a/src/test/java/com/caffeine/acs_backend/controller/AuthControllerTest.java
+++ b/src/test/java/com/caffeine/acs_backend/controller/AuthControllerTest.java
@@ -132,7 +132,7 @@ class AuthControllerTest {
         .andExpect(status().isUnauthorized());
   }
 
-// ── Refresh ─────────────────────────────────────────────────────────────────
+  // ── Refresh ─────────────────────────────────────────────────────────────────
 
   @Test
   void refresh_validRefreshToken_returns200WithNewAccessToken() throws Exception {
@@ -263,9 +263,6 @@ class AuthControllerTest {
             .getContentAsString();
 
     var tree = objectMapper.readTree(responseBody);
-    return new String[]{
-        tree.get("accessToken").asText(),
-        tree.get("refreshToken").asText()
-    };
+    return new String[] {tree.get("accessToken").asText(), tree.get("refreshToken").asText()};
   }
 }

--- a/src/test/java/com/caffeine/acs_backend/controller/AuthControllerTest.java
+++ b/src/test/java/com/caffeine/acs_backend/controller/AuthControllerTest.java
@@ -136,58 +136,58 @@ class AuthControllerTest {
 
   @Test
   void refresh_validRefreshToken_returns200WithNewAccessToken() throws Exception {
-      String email = uniqueEmail();
-      String[] tokens = registerUser(email, "password123");
+    String email = uniqueEmail();
+    String[] tokens = registerUser(email, "password123");
 
-      var request = new RefreshRequest(tokens[1]);
+    var request = new RefreshRequest(tokens[1]);
 
-      mockMvc
-          .perform(
-              post("/api/auth/refresh")
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(objectMapper.writeValueAsString(request)))
-          .andExpect(status().isOk())
-          .andExpect(jsonPath("$.accessToken").isNotEmpty())
-          .andExpect(jsonPath("$.refreshToken").isNotEmpty());
+    mockMvc
+        .perform(
+            post("/api/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.accessToken").isNotEmpty())
+        .andExpect(jsonPath("$.refreshToken").isNotEmpty());
   }
 
   @Test
   void refresh_accessTokenInsteadOfRefresh_returns401() throws Exception {
-      String email = uniqueEmail();
-      String[] tokens = registerUser(email, "password123");
+    String email = uniqueEmail();
+    String[] tokens = registerUser(email, "password123");
 
-      var request = new RefreshRequest(tokens[0]); // передаём access вместо refresh
+    var request = new RefreshRequest(tokens[0]); // передаём access вместо refresh
 
-      mockMvc
-          .perform(
-              post("/api/auth/refresh")
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(objectMapper.writeValueAsString(request)))
-          .andExpect(status().isUnauthorized());
+    mockMvc
+        .perform(
+            post("/api/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isUnauthorized());
   }
 
   @Test
   void refresh_invalidToken_returns401() throws Exception {
-      var request = new RefreshRequest("invalid.token.here");
+    var request = new RefreshRequest("invalid.token.here");
 
-      mockMvc
-          .perform(
-              post("/api/auth/refresh")
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(objectMapper.writeValueAsString(request)))
-          .andExpect(status().isUnauthorized());
+    mockMvc
+        .perform(
+            post("/api/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isUnauthorized());
   }
 
   @Test
   void refresh_blankToken_returns400() throws Exception {
-      var request = new RefreshRequest("");
+    var request = new RefreshRequest("");
 
-      mockMvc
-          .perform(
-              post("/api/auth/refresh")
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(objectMapper.writeValueAsString(request)))
-          .andExpect(status().isBadRequest());
+    mockMvc
+        .perform(
+            post("/api/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
   }
 
   // ── Protected endpoints ─────────────────────────────────────────────────────
@@ -250,22 +250,22 @@ class AuthControllerTest {
   // ── Helpers ─────────────────────────────────────────────────────────────────
 
   private String[] registerUser(String email, String password) throws Exception {
-      var request = new RegisterRequest(email, password);
-      String responseBody =
-          mockMvc
-              .perform(
-                  post("/api/auth/register")
-                      .contentType(MediaType.APPLICATION_JSON)
-                      .content(objectMapper.writeValueAsString(request)))
-              .andExpect(status().isOk())
-              .andReturn()
-              .getResponse()
-              .getContentAsString();
+    var request = new RegisterRequest(email, password);
+    String responseBody =
+        mockMvc
+            .perform(
+                post("/api/auth/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
 
-      var tree = objectMapper.readTree(responseBody);
-      return new String[]{
-          tree.get("accessToken").asText(),
-          tree.get("refreshToken").asText()
-      };
+    var tree = objectMapper.readTree(responseBody);
+    return new String[]{
+        tree.get("accessToken").asText(),
+        tree.get("refreshToken").asText()
+    };
   }
 }

--- a/src/test/java/com/caffeine/acs_backend/security/JwtServiceTest.java
+++ b/src/test/java/com/caffeine/acs_backend/security/JwtServiceTest.java
@@ -28,6 +28,7 @@ class JwtServiceTest {
     jwtService = new JwtService();
     ReflectionTestUtils.setField(jwtService, "secret", MOCK_TEST_SECRET);
     ReflectionTestUtils.setField(jwtService, "expirationMs", EXPIRATION_MS);
+    ReflectionTestUtils.setField(jwtService, "refreshExpirationMs", EXPIRATION_MS * 2);
     ReflectionTestUtils.invokeMethod(jwtService, "initSigningKey");
 
     userDetails =
@@ -35,36 +36,36 @@ class JwtServiceTest {
   }
 
   @Test
-  void generateToken_returnsNonNullToken() {
-    String token = jwtService.generateToken(userDetails);
+  void generateAccessToken_returnsNonNullToken() {
+    String token = jwtService.generateAccessToken(userDetails);
 
     assertThat(token).isNotNull().isNotBlank();
   }
 
   @Test
-  void generateToken_tokenHasThreeParts() {
-    String token = jwtService.generateToken(userDetails);
+  void generateAccessToken_tokenHasThreeParts() {
+    String token = jwtService.generateAccessToken(userDetails);
 
     assertThat(token.split("\\.")).hasSize(3);
   }
 
   @Test
   void extractUsername_returnsCorrectEmail() {
-    String token = jwtService.generateToken(userDetails);
+    String token = jwtService.generateAccessToken(userDetails);
 
     assertThat(jwtService.extractUsername(token)).isEqualTo("test@example.com");
   }
 
   @Test
   void isTokenValid_validTokenAndMatchingUser_returnsTrue() {
-    String token = jwtService.generateToken(userDetails);
+    String token = jwtService.generateAccessToken(userDetails);
 
     assertThat(jwtService.isTokenValid(token, userDetails)).isTrue();
   }
 
   @Test
   void isTokenValid_validTokenButDifferentUser_returnsFalse() {
-    String token = jwtService.generateToken(userDetails);
+    String token = jwtService.generateAccessToken(userDetails);
     UserDetails otherUser =
         User.withUsername("other@example.com").password("password").roles("VISITOR").build();
 
@@ -105,4 +106,40 @@ class JwtServiceTest {
     assertThatThrownBy(() -> jwtService.extractClaims(foreignToken))
         .isInstanceOf(JwtException.class);
   }
+
+  @Test
+  void generateRefreshToken_returnsNonNullToken() {
+    String token = jwtService.generateRefreshToken(userDetails);
+
+    assertThat(token).isNotNull().isNotBlank();
+  }
+
+@Test
+void generateAccessToken_claimTypeIsAccess() {
+    String token = jwtService.generateAccessToken(userDetails);
+
+    assertThat(jwtService.extractClaims(token).get("type", String.class)).isEqualTo("access");
+}
+
+@Test
+void generateRefreshToken_claimTypeIsRefresh() {
+    String token = jwtService.generateRefreshToken(userDetails);
+
+    assertThat(jwtService.extractClaims(token).get("type", String.class)).isEqualTo("refresh");
+}
+
+@Test
+void isTokenValid_expiredToken_returnsFalse() {
+    String expiredToken =
+        Jwts.builder()
+            .subject("test@example.com")
+            .issuedAt(new Date(System.currentTimeMillis() - 2000))
+            .expiration(new Date(System.currentTimeMillis() - 1000))
+            .signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(MOCK_TEST_SECRET)))
+            .compact();
+
+    // expired tokens throw on parse, so isTokenValid should propagate the exception
+    assertThatThrownBy(() -> jwtService.isTokenValid(expiredToken, userDetails))
+        .isInstanceOf(JwtException.class);
+}
 }

--- a/src/test/java/com/caffeine/acs_backend/security/JwtServiceTest.java
+++ b/src/test/java/com/caffeine/acs_backend/security/JwtServiceTest.java
@@ -114,32 +114,32 @@ class JwtServiceTest {
     assertThat(token).isNotNull().isNotBlank();
   }
 
-@Test
-void generateAccessToken_claimTypeIsAccess() {
-    String token = jwtService.generateAccessToken(userDetails);
+  @Test
+  void generateAccessToken_claimTypeIsAccess() {
+      String token = jwtService.generateAccessToken(userDetails);
 
-    assertThat(jwtService.extractClaims(token).get("type", String.class)).isEqualTo("access");
-}
+      assertThat(jwtService.extractClaims(token).get("type", String.class)).isEqualTo("access");
+  }
 
-@Test
-void generateRefreshToken_claimTypeIsRefresh() {
-    String token = jwtService.generateRefreshToken(userDetails);
+  @Test
+  void generateRefreshToken_claimTypeIsRefresh() {
+      String token = jwtService.generateRefreshToken(userDetails);
 
-    assertThat(jwtService.extractClaims(token).get("type", String.class)).isEqualTo("refresh");
-}
+      assertThat(jwtService.extractClaims(token).get("type", String.class)).isEqualTo("refresh");
+  }
 
-@Test
-void isTokenValid_expiredToken_returnsFalse() {
-    String expiredToken =
-        Jwts.builder()
-            .subject("test@example.com")
-            .issuedAt(new Date(System.currentTimeMillis() - 2000))
-            .expiration(new Date(System.currentTimeMillis() - 1000))
-            .signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(MOCK_TEST_SECRET)))
-            .compact();
+  @Test
+  void isTokenValid_expiredToken_returnsFalse() {
+      String expiredToken =
+          Jwts.builder()
+              .subject("test@example.com")
+              .issuedAt(new Date(System.currentTimeMillis() - 2000))
+              .expiration(new Date(System.currentTimeMillis() - 1000))
+              .signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(MOCK_TEST_SECRET)))
+              .compact();
 
-    // expired tokens throw on parse, so isTokenValid should propagate the exception
-    assertThatThrownBy(() -> jwtService.isTokenValid(expiredToken, userDetails))
-        .isInstanceOf(JwtException.class);
-}
+      // expired tokens throw on parse, so isTokenValid should propagate the exception
+      assertThatThrownBy(() -> jwtService.isTokenValid(expiredToken, userDetails))
+          .isInstanceOf(JwtException.class);
+  }
 }

--- a/src/test/java/com/caffeine/acs_backend/security/JwtServiceTest.java
+++ b/src/test/java/com/caffeine/acs_backend/security/JwtServiceTest.java
@@ -116,30 +116,30 @@ class JwtServiceTest {
 
   @Test
   void generateAccessToken_claimTypeIsAccess() {
-      String token = jwtService.generateAccessToken(userDetails);
+    String token = jwtService.generateAccessToken(userDetails);
 
-      assertThat(jwtService.extractClaims(token).get("type", String.class)).isEqualTo("access");
+    assertThat(jwtService.extractClaims(token).get("type", String.class)).isEqualTo("access");
   }
 
   @Test
   void generateRefreshToken_claimTypeIsRefresh() {
-      String token = jwtService.generateRefreshToken(userDetails);
+    String token = jwtService.generateRefreshToken(userDetails);
 
-      assertThat(jwtService.extractClaims(token).get("type", String.class)).isEqualTo("refresh");
+    assertThat(jwtService.extractClaims(token).get("type", String.class)).isEqualTo("refresh");
   }
 
   @Test
   void isTokenValid_expiredToken_returnsFalse() {
-      String expiredToken =
-          Jwts.builder()
-              .subject("test@example.com")
-              .issuedAt(new Date(System.currentTimeMillis() - 2000))
-              .expiration(new Date(System.currentTimeMillis() - 1000))
-              .signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(MOCK_TEST_SECRET)))
-              .compact();
+    String expiredToken =
+        Jwts.builder()
+            .subject("test@example.com")
+            .issuedAt(new Date(System.currentTimeMillis() - 2000))
+            .expiration(new Date(System.currentTimeMillis() - 1000))
+            .signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(MOCK_TEST_SECRET)))
+            .compact();
 
-      // expired tokens throw on parse, so isTokenValid should propagate the exception
-      assertThatThrownBy(() -> jwtService.isTokenValid(expiredToken, userDetails))
-          .isInstanceOf(JwtException.class);
+    // expired tokens throw on parse, so isTokenValid should propagate the exception
+    assertThatThrownBy(() -> jwtService.isTokenValid(expiredToken, userDetails))
+        .isInstanceOf(JwtException.class);
   }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -11,4 +11,5 @@ spring.liquibase.enabled=false
 # ===== JWT EXAMPLE SECRET -> It's only needed so that when @SpringBootTest boots the full Spring context  =====
 # Hardcoded test fixture only - not a real secret.
 jwt.secret=dGVzdFNlY3JldEtleVdoaWNoSXNMb25nRW5vdWdoRm9ySG1hY1NoYTI1Ng==
-jwt.expiration=86400000
+jwt.expiration=7200000
+jwt.refresh-expiration=172800000


### PR DESCRIPTION
Implemented JWT access refresh token.

Tested with various scenarios:

General access token refresh - WORKS
Invalid refresh token as input, expected access token to be not updated - WORKS
Refresh token expiration check, expected access token to be not updated - WORKS
Also, updated all relevant tests and added new ones