### PR TITLE
Feature/29 create visitor registration keycard assignment api endpoints

### DIFF
--- a/src/main/java/com/caffeine/acs_backend/controller/AccessPointController.java
+++ b/src/main/java/com/caffeine/acs_backend/controller/AccessPointController.java
@@ -1,0 +1,34 @@
+package com.caffeine.acs_backend.controller;
+
+import com.caffeine.acs_backend.dto.accesspoint.AccessPointResponse;
+import com.caffeine.acs_backend.service.AccessPointService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/access-points")
+@RequiredArgsConstructor
+@Tag(name = "Access Points")
+@SecurityRequirement(name = "bearerAuth")
+public class AccessPointController {
+
+  private final AccessPointService accessPointService;
+
+  @Operation(
+      summary = "List all access points",
+      description = "Returns all access points sorted alphabetically")
+  @ApiResponse(responseCode = "200", description = "Access point list returned")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @GetMapping
+  public ResponseEntity<List<AccessPointResponse>> getAllAccessPoints() {
+    return ResponseEntity.ok(accessPointService.getAllAccessPoints());
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/controller/DocumentTypeController.java
+++ b/src/main/java/com/caffeine/acs_backend/controller/DocumentTypeController.java
@@ -1,0 +1,34 @@
+package com.caffeine.acs_backend.controller;
+
+import com.caffeine.acs_backend.dto.documenttype.DocumentTypeResponse;
+import com.caffeine.acs_backend.service.DocumentTypeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/document-types")
+@RequiredArgsConstructor
+@Tag(name = "Document Types")
+@SecurityRequirement(name = "bearerAuth")
+public class DocumentTypeController {
+
+  private final DocumentTypeService documentTypeService;
+
+  @Operation(
+      summary = "List all document types",
+      description = "Returns all document types sorted alphabetically")
+  @ApiResponse(responseCode = "200", description = "Document type list returned")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @GetMapping
+  public ResponseEntity<List<DocumentTypeResponse>> getAll() {
+    return ResponseEntity.ok(documentTypeService.getAll());
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/controller/DocumentTypeController.java
+++ b/src/main/java/com/caffeine/acs_backend/controller/DocumentTypeController.java
@@ -16,16 +16,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/document-types")
 @RequiredArgsConstructor
-@Tag(name = "Document Types")
+@Tag(name = "Identity document Types")
 @SecurityRequirement(name = "bearerAuth")
 public class DocumentTypeController {
 
   private final DocumentTypeService documentTypeService;
 
   @Operation(
-      summary = "List all document types",
-      description = "Returns all document types sorted alphabetically")
-  @ApiResponse(responseCode = "200", description = "Document type list returned")
+      summary = "List all identity document types",
+      description = "Returns all identity document types sorted alphabetically")
+  @ApiResponse(responseCode = "200", description = "Identity document type list returned")
   @ApiResponse(responseCode = "401", description = "Unauthorized")
   @GetMapping
   public ResponseEntity<List<DocumentTypeResponse>> getAll() {

--- a/src/main/java/com/caffeine/acs_backend/controller/KeycardController.java
+++ b/src/main/java/com/caffeine/acs_backend/controller/KeycardController.java
@@ -24,8 +24,7 @@ public class KeycardController {
 
   @Operation(
       summary = "List available keycards",
-      description =
-          "Returns all active keycards that are not currently assigned to anyone.")
+      description = "Returns all active keycards that are not currently assigned to anyone.")
   @ApiResponse(responseCode = "200", description = "Available keycard list returned")
   @ApiResponse(responseCode = "401", description = "Unauthorized")
   @GetMapping("/available")

--- a/src/main/java/com/caffeine/acs_backend/controller/KeycardController.java
+++ b/src/main/java/com/caffeine/acs_backend/controller/KeycardController.java
@@ -1,0 +1,35 @@
+package com.caffeine.acs_backend.controller;
+
+import com.caffeine.acs_backend.dto.keycard.KeycardResponse;
+import com.caffeine.acs_backend.service.KeycardService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/keycards")
+@RequiredArgsConstructor
+@Tag(name = "Keycards", description = "Keycard management")
+@SecurityRequirement(name = "bearerAuth")
+public class KeycardController {
+
+  private final KeycardService keycardService;
+
+  @Operation(
+      summary = "List available keycards",
+      description =
+          "Returns all active keycards that are not currently assigned to anyone.")
+  @ApiResponse(responseCode = "200", description = "Available keycard list returned")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @GetMapping("/available")
+  public ResponseEntity<List<KeycardResponse>> getAvailableKeycards() {
+    return ResponseEntity.ok(keycardService.getAvailableKeycards());
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/controller/NationalityController.java
+++ b/src/main/java/com/caffeine/acs_backend/controller/NationalityController.java
@@ -1,0 +1,34 @@
+package com.caffeine.acs_backend.controller;
+
+import com.caffeine.acs_backend.dto.nationality.NationalityResponse;
+import com.caffeine.acs_backend.service.NationalityService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/nationalities")
+@RequiredArgsConstructor
+@Tag(name = "Nationalities", description = "Reference data — nationality list for visitor form")
+@SecurityRequirement(name = "bearerAuth")
+public class NationalityController {
+
+  private final NationalityService nationalityService;
+
+  @Operation(
+      summary = "List all nationalities",
+      description = "Returns all allowed nationalities sorted alphabetically.")
+  @ApiResponse(responseCode = "200", description = "Nationality list returned")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @GetMapping
+  public ResponseEntity<List<NationalityResponse>> getAllNationalities() {
+    return ResponseEntity.ok(nationalityService.getAllNationalities());
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/controller/PersonController.java
+++ b/src/main/java/com/caffeine/acs_backend/controller/PersonController.java
@@ -1,0 +1,42 @@
+package com.caffeine.acs_backend.controller;
+
+import com.caffeine.acs_backend.dto.person.PersonInRoleResponse;
+import com.caffeine.acs_backend.service.PersonService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/persons")
+@RequiredArgsConstructor
+@Tag(name = "Persons", description = "Person search")
+@SecurityRequirement(name = "bearerAuth")
+public class PersonController {
+
+  private final PersonService personService;
+
+  @Operation(
+      summary = "Search persons by name",
+      description =
+          "Returns person records whose first or last name contains the query string."
+              + " Optionally filter by role name.")
+  @ApiResponse(responseCode = "200", description = "Search results returned (may be empty)")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @GetMapping("/search")
+  public ResponseEntity<List<PersonInRoleResponse>> search(
+      @Parameter(description = "Name fragment to search for", example = "Jane")
+          @RequestParam String q,
+      @Parameter(description = "Role name to filter by (optional)", example = "Employee")
+          @RequestParam(required = false) String role) {
+    return ResponseEntity.ok(personService.search(q, role));
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/controller/PersonController.java
+++ b/src/main/java/com/caffeine/acs_backend/controller/PersonController.java
@@ -1,16 +1,22 @@
 package com.caffeine.acs_backend.controller;
 
+import com.caffeine.acs_backend.dto.person.CreatePersonRequest;
 import com.caffeine.acs_backend.dto.person.PersonInRoleResponse;
+import com.caffeine.acs_backend.dto.person.PersonResponse;
 import com.caffeine.acs_backend.service.PersonService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,6 +29,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class PersonController {
 
   private final PersonService personService;
+
+  @Operation(
+      summary = "Create a new person",
+      description = "Creates a new person record, optionally with a document.")
+  @ApiResponse(responseCode = "201", description = "Person created")
+  @ApiResponse(responseCode = "400", description = "Validation error")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @PostMapping
+  public ResponseEntity<PersonResponse> createPerson(@Valid @RequestBody CreatePersonRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED).body(personService.createPerson(request));
+  }
 
   @Operation(
       summary = "Search persons by name",

--- a/src/main/java/com/caffeine/acs_backend/controller/PersonController.java
+++ b/src/main/java/com/caffeine/acs_backend/controller/PersonController.java
@@ -37,7 +37,8 @@ public class PersonController {
   @ApiResponse(responseCode = "400", description = "Validation error")
   @ApiResponse(responseCode = "401", description = "Unauthorized")
   @PostMapping
-  public ResponseEntity<PersonResponse> createPerson(@Valid @RequestBody CreatePersonRequest request) {
+  public ResponseEntity<PersonResponse> createPerson(
+      @Valid @RequestBody CreatePersonRequest request) {
     return ResponseEntity.status(HttpStatus.CREATED).body(personService.createPerson(request));
   }
 
@@ -50,10 +51,11 @@ public class PersonController {
   @ApiResponse(responseCode = "401", description = "Unauthorized")
   @GetMapping("/search")
   public ResponseEntity<List<PersonInRoleResponse>> search(
-      @Parameter(description = "Name fragment to search for", example = "Jane")
-          @RequestParam String q,
+      @Parameter(description = "Name fragment to search for", example = "Jane") @RequestParam
+          String q,
       @Parameter(description = "Role name to filter by (optional)", example = "Employee")
-          @RequestParam(required = false) String role) {
+          @RequestParam(required = false)
+          String role) {
     return ResponseEntity.ok(personService.search(q, role));
   }
 }

--- a/src/main/java/com/caffeine/acs_backend/controller/VisitController.java
+++ b/src/main/java/com/caffeine/acs_backend/controller/VisitController.java
@@ -37,8 +37,8 @@ public class VisitController {
   @ApiResponse(responseCode = "401", description = "Unauthorized")
   @PostMapping
   public ResponseEntity<CreateVisitResponse> createVisit(
-      @Valid @RequestBody CreateVisitRequest request,
-      @AuthenticationPrincipal User currentUser) {
-    return ResponseEntity.status(HttpStatus.CREATED).body(visitService.createVisit(request, currentUser));
+      @Valid @RequestBody CreateVisitRequest request, @AuthenticationPrincipal User currentUser) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(visitService.createVisit(request, currentUser));
   }
 }

--- a/src/main/java/com/caffeine/acs_backend/controller/VisitController.java
+++ b/src/main/java/com/caffeine/acs_backend/controller/VisitController.java
@@ -1,0 +1,44 @@
+package com.caffeine.acs_backend.controller;
+
+import com.caffeine.acs_backend.dto.visit.CreateVisitRequest;
+import com.caffeine.acs_backend.dto.visit.CreateVisitResponse;
+import com.caffeine.acs_backend.entity.User;
+import com.caffeine.acs_backend.service.VisitService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/visits")
+@RequiredArgsConstructor
+@Tag(name = "Visits", description = "Visit registration")
+@SecurityRequirement(name = "bearerAuth")
+public class VisitController {
+
+  private final VisitService visitService;
+
+  @Operation(
+      summary = "Record a new visit",
+      description =
+          "Records a visit and assigns a keycard to an visitor"
+              + " The authenticated user acts as the assignor.")
+  @ApiResponse(responseCode = "201", description = "Visit recorded and keycard assigned for person")
+  @ApiResponse(responseCode = "400", description = "Validation error or keycard already assigned")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @PostMapping
+  public ResponseEntity<CreateVisitResponse> createVisit(
+      @Valid @RequestBody CreateVisitRequest request,
+      @AuthenticationPrincipal User currentUser) {
+    return ResponseEntity.status(HttpStatus.CREATED).body(visitService.createVisit(request, currentUser));
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/dto/accesspoint/AccessPointResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/accesspoint/AccessPointResponse.java
@@ -1,0 +1,18 @@
+package com.caffeine.acs_backend.dto.accesspoint;
+
+import com.caffeine.acs_backend.entity.AccessPoint;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+@Schema(description = "Access point option for dropdown selection")
+public record AccessPointResponse(
+    @Schema(description = "Unique identifier", example = "550e8400-e29b-41d4-a716-446655440000")
+        UUID id,
+    @Schema(description = "Name of the access point", example = "Main entrance") String name,
+    @Schema(description = "Physical address", example = "Building A, Gate 1") String address) {
+
+  public static AccessPointResponse from(AccessPoint accessPoint) {
+    return new AccessPointResponse(
+        accessPoint.getId(), accessPoint.getName(), accessPoint.getAddress());
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/dto/documenttype/DocumentTypeResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/documenttype/DocumentTypeResponse.java
@@ -4,10 +4,10 @@ import com.caffeine.acs_backend.entity.DocumentType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.UUID;
 
-@Schema(description = "Document type for selection in person registration")
+@Schema(description = "Identity document type for selection in person registration")
 public record DocumentTypeResponse(
     @Schema(description = "Unique identifier") UUID id,
-    @Schema(description = "Document type name", example = "Passport") String name) {
+    @Schema(description = "Identity document type name", example = "Passport") String name) {
 
   public static DocumentTypeResponse from(DocumentType documentType) {
     return new DocumentTypeResponse(documentType.getId(), documentType.getName());

--- a/src/main/java/com/caffeine/acs_backend/dto/documenttype/DocumentTypeResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/documenttype/DocumentTypeResponse.java
@@ -1,0 +1,15 @@
+package com.caffeine.acs_backend.dto.documenttype;
+
+import com.caffeine.acs_backend.entity.DocumentType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+@Schema(description = "Document type for selection in person registration")
+public record DocumentTypeResponse(
+    @Schema(description = "Unique identifier") UUID id,
+    @Schema(description = "Document type name", example = "Passport") String name) {
+
+  public static DocumentTypeResponse from(DocumentType documentType) {
+    return new DocumentTypeResponse(documentType.getId(), documentType.getName());
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/dto/keycard/KeycardResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/keycard/KeycardResponse.java
@@ -1,0 +1,17 @@
+package com.caffeine.acs_backend.dto.keycard;
+
+import com.caffeine.acs_backend.entity.Keycard;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(description = "Available keycard for assignment")
+public record KeycardResponse(
+    @Schema(description = "Unique identifier") UUID id,
+    @Schema(description = "Keycard number printed on the card", example = "CARD-0042") String keycardNumber,
+    @Schema(description = "Expiration date/time of the keycard, null means no expiry") LocalDateTime validUntil) {
+
+  public static KeycardResponse from(Keycard keycard) {
+    return new KeycardResponse(keycard.getId(), keycard.getKeycardNumber(), keycard.getValidUntil());
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/dto/keycard/KeycardResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/keycard/KeycardResponse.java
@@ -8,10 +8,13 @@ import java.util.UUID;
 @Schema(description = "Available keycard for assignment")
 public record KeycardResponse(
     @Schema(description = "Unique identifier") UUID id,
-    @Schema(description = "Keycard number printed on the card", example = "CARD-0042") String keycardNumber,
-    @Schema(description = "Expiration date/time of the keycard, null means no expiry") LocalDateTime validUntil) {
+    @Schema(description = "Keycard number printed on the card", example = "CARD-0042")
+        String keycardNumber,
+    @Schema(description = "Expiration date/time of the keycard, null means no expiry")
+        LocalDateTime validUntil) {
 
   public static KeycardResponse from(Keycard keycard) {
-    return new KeycardResponse(keycard.getId(), keycard.getKeycardNumber(), keycard.getValidUntil());
+    return new KeycardResponse(
+        keycard.getId(), keycard.getKeycardNumber(), keycard.getValidUntil());
   }
 }

--- a/src/main/java/com/caffeine/acs_backend/dto/nationality/NationalityResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/nationality/NationalityResponse.java
@@ -1,0 +1,18 @@
+package com.caffeine.acs_backend.dto.nationality;
+
+import com.caffeine.acs_backend.entity.Nationality;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+@Schema(description = "Nationality option for dropdown selection")
+public record NationalityResponse(
+    @Schema(description = "Unique identifier", example = "550e8400-e29b-41d4-a716-446655440000")
+        UUID id,
+    @Schema(description = "Country name", example = "Estonia") String name,
+    @Schema(description = "ISO 3166-1 alpha-2 country code", example = "EE") String countryCode) {
+
+  public static NationalityResponse from(Nationality nationality) {
+    return new NationalityResponse(
+        nationality.getId(), nationality.getName(), nationality.getCountryCode());
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/dto/person/CreatePersonRequest.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/person/CreatePersonRequest.java
@@ -8,8 +8,12 @@ import java.util.UUID;
 
 @Schema(description = "Request body for creating a new person")
 public record CreatePersonRequest(
-    @Schema(description = "First name", example = "John") @NotBlank @Size(max = 128) String givenName,
+    @Schema(description = "First name", example = "John") @NotBlank @Size(max = 128)
+        String givenName,
     @Schema(description = "Last name", example = "Smith") @NotBlank @Size(max = 128) String surname,
     @Schema(description = "Nationality ID") @NotNull UUID nationalityId,
-    @Schema(description = "Document type ID — required when documentNumber is provided") UUID documentTypeId,
-    @Schema(description = "Document number (e.g. passport number)", example = "AB1234567") @Size(max = 128) String documentNumber) {}
+    @Schema(description = "Document type ID — required when documentNumber is provided")
+        UUID documentTypeId,
+    @Schema(description = "Document number (e.g. passport number)", example = "AB1234567")
+        @Size(max = 128)
+        String documentNumber) {}

--- a/src/main/java/com/caffeine/acs_backend/dto/person/CreatePersonRequest.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/person/CreatePersonRequest.java
@@ -1,0 +1,15 @@
+package com.caffeine.acs_backend.dto.person;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+@Schema(description = "Request body for creating a new person")
+public record CreatePersonRequest(
+    @Schema(description = "First name", example = "John") @NotBlank @Size(max = 128) String givenName,
+    @Schema(description = "Last name", example = "Smith") @NotBlank @Size(max = 128) String surname,
+    @Schema(description = "Nationality ID") @NotNull UUID nationalityId,
+    @Schema(description = "Document type ID — required when documentNumber is provided") UUID documentTypeId,
+    @Schema(description = "Document number (e.g. passport number)", example = "AB1234567") @Size(max = 128) String documentNumber) {}

--- a/src/main/java/com/caffeine/acs_backend/dto/person/CreatePersonRequest.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/person/CreatePersonRequest.java
@@ -12,7 +12,7 @@ public record CreatePersonRequest(
         String givenName,
     @Schema(description = "Last name", example = "Smith") @NotBlank @Size(max = 128) String surname,
     @Schema(description = "Nationality ID") @NotNull UUID nationalityId,
-    @Schema(description = "Document type ID — required when documentNumber is provided")
+    @Schema(description = "Identity document type ID — required when documentNumber is provided")
         UUID documentTypeId,
     @Schema(description = "Document number (e.g. passport number)", example = "AB1234567")
         @Size(max = 128)

--- a/src/main/java/com/caffeine/acs_backend/dto/person/PersonInRoleResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/person/PersonInRoleResponse.java
@@ -1,0 +1,23 @@
+package com.caffeine.acs_backend.dto.person;
+
+import com.caffeine.acs_backend.entity.PersonInRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+@Schema(description = "Person in a role — used for host/assignor search results")
+public record PersonInRoleResponse(
+    @Schema(description = "PersonInRole unique identifier") UUID id,
+    @Schema(description = "Person unique identifier") UUID personId,
+    @Schema(description = "First name", example = "Jane") String givenName,
+    @Schema(description = "Last name", example = "Doe") String surname,
+    @Schema(description = "Role name", example = "Receptionist") String roleName) {
+
+  public static PersonInRoleResponse from(PersonInRole pir) {
+    return new PersonInRoleResponse(
+        pir.getId(),
+        pir.getPerson().getId(),
+        pir.getPerson().getGivenName(),
+        pir.getPerson().getSurname(),
+        pir.getRole().getName());
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/dto/person/PersonResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/person/PersonResponse.java
@@ -1,0 +1,21 @@
+package com.caffeine.acs_backend.dto.person;
+
+import com.caffeine.acs_backend.entity.Person;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+@Schema(description = "Created person details")
+public record PersonResponse(
+    @Schema(description = "Person unique identifier") UUID id,
+    @Schema(description = "First name", example = "John") String givenName,
+    @Schema(description = "Last name", example = "Smith") String surname,
+    @Schema(description = "Nationality name", example = "Estonian") String nationality) {
+
+  public static PersonResponse from(Person person) {
+    return new PersonResponse(
+        person.getId(),
+        person.getGivenName(),
+        person.getSurname(),
+        person.getNationality().getName());
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/dto/visit/CreateVisitRequest.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/visit/CreateVisitRequest.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 public record CreateVisitRequest(
     @Schema(description = "ID of the person visiting") @NotNull UUID personId,
     @Schema(description = "Access point where the visit takes place") @NotNull UUID accessPointId,
-    @Schema(description = "ID of the available keycard to assign") @NotNull UUID keycardId,
+    @Schema(description = "ID of the available keycard to assign — optional") UUID keycardId,
     @Schema(description = "PersonInRole ID of the host — optional") UUID hostPersonInRoleId,
     @Schema(description = "Purpose or notes about the visit", example = "Q1 review meeting")
         @Size(max = 1024)

--- a/src/main/java/com/caffeine/acs_backend/dto/visit/CreateVisitRequest.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/visit/CreateVisitRequest.java
@@ -1,0 +1,19 @@
+package com.caffeine.acs_backend.dto.visit;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(description = "Request body for recording a visit and assigning a keycard")
+public record CreateVisitRequest(
+    @Schema(description = "ID of the person visiting") @NotNull UUID personId,
+    @Schema(description = "Access point where the visit takes place") @NotNull UUID accessPointId,
+    @Schema(description = "ID of the available keycard to assign") @NotNull UUID keycardId,
+    @Schema(description = "PersonInRole ID of the host — optional") UUID hostPersonInRoleId,
+    @Schema(description = "Purpose or notes about the visit", example = "Q1 review meeting")
+        @Size(max = 1024)
+        String comment,
+    @Schema(description = "Arrival time — defaults to current time if not provided")
+        LocalDateTime arrivalTime) {}

--- a/src/main/java/com/caffeine/acs_backend/dto/visit/CreateVisitResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/visit/CreateVisitResponse.java
@@ -8,7 +8,9 @@ import java.util.UUID;
 public record CreateVisitResponse(
     @Schema(description = "Created visit ID") UUID visitId,
     @Schema(description = "Person ID of the visitor") UUID personId,
-    @Schema(description = "PersonInRole ID representing the visitor role assignment") UUID personInRoleId,
+    @Schema(description = "PersonInRole ID representing the visitor role assignment")
+        UUID personInRoleId,
     @Schema(description = "KeycardInPossession record ID") UUID keycardInPossessionId,
-    @Schema(description = "Keycard number that was assigned", example = "CARD-0042") String keycardNumber,
+    @Schema(description = "Keycard number that was assigned", example = "CARD-0042")
+        String keycardNumber,
     @Schema(description = "Recorded arrival time") LocalDateTime arrivalTime) {}

--- a/src/main/java/com/caffeine/acs_backend/dto/visit/CreateVisitResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/visit/CreateVisitResponse.java
@@ -1,0 +1,14 @@
+package com.caffeine.acs_backend.dto.visit;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(description = "Result of a successfully recorded visit")
+public record CreateVisitResponse(
+    @Schema(description = "Created visit ID") UUID visitId,
+    @Schema(description = "Person ID of the visitor") UUID personId,
+    @Schema(description = "PersonInRole ID representing the visitor role assignment") UUID personInRoleId,
+    @Schema(description = "KeycardInPossession record ID") UUID keycardInPossessionId,
+    @Schema(description = "Keycard number that was assigned", example = "CARD-0042") String keycardNumber,
+    @Schema(description = "Recorded arrival time") LocalDateTime arrivalTime) {}

--- a/src/main/java/com/caffeine/acs_backend/repository/AccessPointRepository.java
+++ b/src/main/java/com/caffeine/acs_backend/repository/AccessPointRepository.java
@@ -1,0 +1,11 @@
+package com.caffeine.acs_backend.repository;
+
+import com.caffeine.acs_backend.entity.AccessPoint;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccessPointRepository extends JpaRepository<AccessPoint, UUID> {
+
+  List<AccessPoint> findAllByOrderByNameAsc();
+}

--- a/src/main/java/com/caffeine/acs_backend/repository/DocumentTypeRepository.java
+++ b/src/main/java/com/caffeine/acs_backend/repository/DocumentTypeRepository.java
@@ -1,0 +1,7 @@
+package com.caffeine.acs_backend.repository;
+
+import com.caffeine.acs_backend.entity.DocumentType;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DocumentTypeRepository extends JpaRepository<DocumentType, UUID> {}

--- a/src/main/java/com/caffeine/acs_backend/repository/KeycardInPossessionRepository.java
+++ b/src/main/java/com/caffeine/acs_backend/repository/KeycardInPossessionRepository.java
@@ -1,0 +1,11 @@
+package com.caffeine.acs_backend.repository;
+
+import com.caffeine.acs_backend.entity.Keycard;
+import com.caffeine.acs_backend.entity.KeycardInPossession;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface KeycardInPossessionRepository extends JpaRepository<KeycardInPossession, UUID> {
+
+  boolean existsByKeycardAndReturnTimeIsNull(Keycard keycard);
+}

--- a/src/main/java/com/caffeine/acs_backend/repository/KeycardRepository.java
+++ b/src/main/java/com/caffeine/acs_backend/repository/KeycardRepository.java
@@ -1,0 +1,18 @@
+package com.caffeine.acs_backend.repository;
+
+import com.caffeine.acs_backend.entity.Keycard;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface KeycardRepository extends JpaRepository<Keycard, UUID> {
+
+  @Query(
+      "SELECT k FROM Keycard k WHERE k.isActive = true"
+          + " AND NOT EXISTS ("
+          + "   SELECT 1 FROM KeycardInPossession kp"
+          + "   WHERE kp.keycard = k AND kp.returnTime IS NULL"
+          + " )")
+  List<Keycard> findAvailableKeycards();
+}

--- a/src/main/java/com/caffeine/acs_backend/repository/KeycardRepository.java
+++ b/src/main/java/com/caffeine/acs_backend/repository/KeycardRepository.java
@@ -10,6 +10,7 @@ public interface KeycardRepository extends JpaRepository<Keycard, UUID> {
 
   @Query(
       "SELECT k FROM Keycard k WHERE k.isActive = true"
+          + " AND (k.validUntil IS NULL OR k.validUntil > CURRENT_TIMESTAMP)"
           + " AND NOT EXISTS ("
           + "   SELECT 1 FROM KeycardInPossession kp"
           + "   WHERE kp.keycard = k AND kp.returnTime IS NULL"

--- a/src/main/java/com/caffeine/acs_backend/repository/NationalityRepository.java
+++ b/src/main/java/com/caffeine/acs_backend/repository/NationalityRepository.java
@@ -1,0 +1,11 @@
+package com.caffeine.acs_backend.repository;
+
+import com.caffeine.acs_backend.entity.Nationality;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NationalityRepository extends JpaRepository<Nationality, UUID> {
+
+  List<Nationality> findAllByOrderByNameAsc();
+}

--- a/src/main/java/com/caffeine/acs_backend/repository/PersonInRoleRepository.java
+++ b/src/main/java/com/caffeine/acs_backend/repository/PersonInRoleRepository.java
@@ -13,7 +13,10 @@ import org.springframework.data.repository.query.Param;
 public interface PersonInRoleRepository extends JpaRepository<PersonInRole, UUID> {
 
   @Query(
-      "SELECT pir FROM PersonInRole pir WHERE pir.isActive = true"
+      "SELECT pir FROM PersonInRole pir"
+          + " JOIN FETCH pir.person"
+          + " JOIN FETCH pir.role"
+          + " WHERE pir.isActive = true"
           + " AND (LOWER(pir.person.givenName) LIKE LOWER(CONCAT('%', :query, '%'))"
           + " OR LOWER(pir.person.surname) LIKE LOWER(CONCAT('%', :query, '%')))"
           + " AND (:role IS NULL OR LOWER(pir.role.name) = LOWER(:role))")

--- a/src/main/java/com/caffeine/acs_backend/repository/PersonInRoleRepository.java
+++ b/src/main/java/com/caffeine/acs_backend/repository/PersonInRoleRepository.java
@@ -20,8 +20,7 @@ public interface PersonInRoleRepository extends JpaRepository<PersonInRole, UUID
           + " AND (LOWER(pir.person.givenName) LIKE LOWER(CONCAT('%', :query, '%'))"
           + " OR LOWER(pir.person.surname) LIKE LOWER(CONCAT('%', :query, '%')))"
           + " AND (:role IS NULL OR LOWER(pir.role.name) = LOWER(:role))")
-  List<PersonInRole> searchByPersonName(
-      @Param("query") String query, @Param("role") String role);
+  List<PersonInRole> searchByPersonName(@Param("query") String query, @Param("role") String role);
 
   Optional<PersonInRole> findFirstByPersonAndIsActiveTrue(Person person);
 

--- a/src/main/java/com/caffeine/acs_backend/repository/PersonInRoleRepository.java
+++ b/src/main/java/com/caffeine/acs_backend/repository/PersonInRoleRepository.java
@@ -2,6 +2,7 @@ package com.caffeine.acs_backend.repository;
 
 import com.caffeine.acs_backend.entity.Person;
 import com.caffeine.acs_backend.entity.PersonInRole;
+import com.caffeine.acs_backend.entity.Role;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -20,4 +21,6 @@ public interface PersonInRoleRepository extends JpaRepository<PersonInRole, UUID
       @Param("query") String query, @Param("role") String role);
 
   Optional<PersonInRole> findFirstByPersonAndIsActiveTrue(Person person);
+
+  Optional<PersonInRole> findByPersonAndRoleAndIsActiveTrue(Person person, Role role);
 }

--- a/src/main/java/com/caffeine/acs_backend/repository/PersonInRoleRepository.java
+++ b/src/main/java/com/caffeine/acs_backend/repository/PersonInRoleRepository.java
@@ -1,0 +1,23 @@
+package com.caffeine.acs_backend.repository;
+
+import com.caffeine.acs_backend.entity.Person;
+import com.caffeine.acs_backend.entity.PersonInRole;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PersonInRoleRepository extends JpaRepository<PersonInRole, UUID> {
+
+  @Query(
+      "SELECT pir FROM PersonInRole pir WHERE pir.isActive = true"
+          + " AND (LOWER(pir.person.givenName) LIKE LOWER(CONCAT('%', :query, '%'))"
+          + " OR LOWER(pir.person.surname) LIKE LOWER(CONCAT('%', :query, '%')))"
+          + " AND (:role IS NULL OR LOWER(pir.role.name) = LOWER(:role))")
+  List<PersonInRole> searchByPersonName(
+      @Param("query") String query, @Param("role") String role);
+
+  Optional<PersonInRole> findFirstByPersonAndIsActiveTrue(Person person);
+}

--- a/src/main/java/com/caffeine/acs_backend/repository/PersonRepository.java
+++ b/src/main/java/com/caffeine/acs_backend/repository/PersonRepository.java
@@ -1,0 +1,7 @@
+package com.caffeine.acs_backend.repository;
+
+import com.caffeine.acs_backend.entity.Person;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PersonRepository extends JpaRepository<Person, UUID> {}

--- a/src/main/java/com/caffeine/acs_backend/repository/RoleRepository.java
+++ b/src/main/java/com/caffeine/acs_backend/repository/RoleRepository.java
@@ -1,0 +1,11 @@
+package com.caffeine.acs_backend.repository;
+
+import com.caffeine.acs_backend.entity.Role;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoleRepository extends JpaRepository<Role, UUID> {
+
+  Optional<Role> findByName(String name);
+}

--- a/src/main/java/com/caffeine/acs_backend/repository/VisitRepository.java
+++ b/src/main/java/com/caffeine/acs_backend/repository/VisitRepository.java
@@ -1,0 +1,7 @@
+package com.caffeine.acs_backend.repository;
+
+import com.caffeine.acs_backend.entity.Visit;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VisitRepository extends JpaRepository<Visit, UUID> {}

--- a/src/main/java/com/caffeine/acs_backend/service/AccessPointService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/AccessPointService.java
@@ -1,0 +1,20 @@
+package com.caffeine.acs_backend.service;
+
+import com.caffeine.acs_backend.dto.accesspoint.AccessPointResponse;
+import com.caffeine.acs_backend.repository.AccessPointRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccessPointService {
+
+  private final AccessPointRepository accessPointRepository;
+
+  public List<AccessPointResponse> getAllAccessPoints() {
+    return accessPointRepository.findAllByOrderByNameAsc().stream()
+        .map(AccessPointResponse::from)
+        .toList();
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/service/DocumentTypeService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/DocumentTypeService.java
@@ -1,6 +1,7 @@
 package com.caffeine.acs_backend.service;
 
 import com.caffeine.acs_backend.dto.documenttype.DocumentTypeResponse;
+import com.caffeine.acs_backend.entity.DocumentType;
 import com.caffeine.acs_backend.repository.DocumentTypeRepository;
 import java.util.Comparator;
 import java.util.List;
@@ -15,7 +16,7 @@ public class DocumentTypeService {
 
   public List<DocumentTypeResponse> getAll() {
     return documentTypeRepository.findAll().stream()
-        .sorted(Comparator.comparing(dt -> dt.getName()))
+        .sorted(Comparator.comparing(DocumentType::getName))
         .map(DocumentTypeResponse::from)
         .toList();
   }

--- a/src/main/java/com/caffeine/acs_backend/service/DocumentTypeService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/DocumentTypeService.java
@@ -1,0 +1,22 @@
+package com.caffeine.acs_backend.service;
+
+import com.caffeine.acs_backend.dto.documenttype.DocumentTypeResponse;
+import com.caffeine.acs_backend.repository.DocumentTypeRepository;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DocumentTypeService {
+
+  private final DocumentTypeRepository documentTypeRepository;
+
+  public List<DocumentTypeResponse> getAll() {
+    return documentTypeRepository.findAll().stream()
+        .sorted(Comparator.comparing(dt -> dt.getName()))
+        .map(DocumentTypeResponse::from)
+        .toList();
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/service/KeycardService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/KeycardService.java
@@ -13,8 +13,6 @@ public class KeycardService {
   private final KeycardRepository keycardRepository;
 
   public List<KeycardResponse> getAvailableKeycards() {
-    return keycardRepository.findAvailableKeycards().stream()
-        .map(KeycardResponse::from)
-        .toList();
+    return keycardRepository.findAvailableKeycards().stream().map(KeycardResponse::from).toList();
   }
 }

--- a/src/main/java/com/caffeine/acs_backend/service/KeycardService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/KeycardService.java
@@ -1,0 +1,20 @@
+package com.caffeine.acs_backend.service;
+
+import com.caffeine.acs_backend.dto.keycard.KeycardResponse;
+import com.caffeine.acs_backend.repository.KeycardRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KeycardService {
+
+  private final KeycardRepository keycardRepository;
+
+  public List<KeycardResponse> getAvailableKeycards() {
+    return keycardRepository.findAvailableKeycards().stream()
+        .map(KeycardResponse::from)
+        .toList();
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/service/NationalityService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/NationalityService.java
@@ -1,0 +1,20 @@
+package com.caffeine.acs_backend.service;
+
+import com.caffeine.acs_backend.dto.nationality.NationalityResponse;
+import com.caffeine.acs_backend.repository.NationalityRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NationalityService {
+
+  private final NationalityRepository nationalityRepository;
+
+  public List<NationalityResponse> getAllNationalities() {
+    return nationalityRepository.findAllByOrderByNameAsc().stream()
+        .map(NationalityResponse::from)
+        .toList();
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/service/PersonService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/PersonService.java
@@ -1,16 +1,64 @@
 package com.caffeine.acs_backend.service;
 
+import com.caffeine.acs_backend.dto.person.CreatePersonRequest;
 import com.caffeine.acs_backend.dto.person.PersonInRoleResponse;
+import com.caffeine.acs_backend.dto.person.PersonResponse;
+import com.caffeine.acs_backend.entity.Document;
+import com.caffeine.acs_backend.entity.DocumentType;
+import com.caffeine.acs_backend.entity.Nationality;
+import com.caffeine.acs_backend.entity.Person;
+import com.caffeine.acs_backend.repository.DocumentTypeRepository;
+import com.caffeine.acs_backend.repository.NationalityRepository;
 import com.caffeine.acs_backend.repository.PersonInRoleRepository;
+import com.caffeine.acs_backend.repository.PersonRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class PersonService {
 
   private final PersonInRoleRepository personInRoleRepository;
+  private final PersonRepository personRepository;
+  private final NationalityRepository nationalityRepository;
+  private final DocumentTypeRepository documentTypeRepository;
+
+  @Transactional
+  public PersonResponse createPerson(CreatePersonRequest request) {
+    Nationality nationality =
+        nationalityRepository
+            .findById(request.nationalityId())
+            .orElseThrow(
+                () -> new IllegalArgumentException("Nationality not found: " + request.nationalityId()));
+
+    Person person =
+        Person.builder()
+            .givenName(request.givenName().trim())
+            .surname(request.surname().trim())
+            .nationality(nationality)
+            .build();
+    personRepository.save(person);
+
+    if (request.documentNumber() != null && !request.documentNumber().isBlank()
+        && request.documentTypeId() != null) {
+      DocumentType documentType =
+          documentTypeRepository
+              .findById(request.documentTypeId())
+              .orElseThrow(
+                  () -> new IllegalArgumentException("Document type not found: " + request.documentTypeId()));
+      person.getDocuments().add(
+          Document.builder()
+              .documentNumber(request.documentNumber())
+              .documentType(documentType)
+              .person(person)
+              .build());
+      personRepository.save(person);
+    }
+
+    return PersonResponse.from(person);
+  }
 
   public List<PersonInRoleResponse> search(String query, String role) {
     if (query == null || query.isBlank()) {

--- a/src/main/java/com/caffeine/acs_backend/service/PersonService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/PersonService.java
@@ -1,0 +1,24 @@
+package com.caffeine.acs_backend.service;
+
+import com.caffeine.acs_backend.dto.person.PersonInRoleResponse;
+import com.caffeine.acs_backend.repository.PersonInRoleRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PersonService {
+
+  private final PersonInRoleRepository personInRoleRepository;
+
+  public List<PersonInRoleResponse> search(String query, String role) {
+    if (query == null || query.isBlank()) {
+      return List.of();
+    }
+    String roleFilter = (role == null || role.isBlank()) ? null : role.trim();
+    return personInRoleRepository.searchByPersonName(query.trim(), roleFilter).stream()
+        .map(PersonInRoleResponse::from)
+        .toList();
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/service/PersonService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/PersonService.java
@@ -31,7 +31,9 @@ public class PersonService {
         nationalityRepository
             .findById(request.nationalityId())
             .orElseThrow(
-                () -> new IllegalArgumentException("Nationality not found: " + request.nationalityId()));
+                () ->
+                    new IllegalArgumentException(
+                        "Nationality not found: " + request.nationalityId()));
 
     Person person =
         Person.builder()
@@ -41,7 +43,8 @@ public class PersonService {
             .build();
     personRepository.save(person);
 
-    boolean hasDocumentNumber = request.documentNumber() != null && !request.documentNumber().isBlank();
+    boolean hasDocumentNumber =
+        request.documentNumber() != null && !request.documentNumber().isBlank();
     boolean hasDocumentTypeId = request.documentTypeId() != null;
     if (hasDocumentNumber != hasDocumentTypeId) {
       throw new IllegalArgumentException(
@@ -52,13 +55,17 @@ public class PersonService {
           documentTypeRepository
               .findById(request.documentTypeId())
               .orElseThrow(
-                  () -> new IllegalArgumentException("Document type not found: " + request.documentTypeId()));
-      person.getDocuments().add(
-          Document.builder()
-              .documentNumber(request.documentNumber())
-              .documentType(documentType)
-              .person(person)
-              .build());
+                  () ->
+                      new IllegalArgumentException(
+                          "Document type not found: " + request.documentTypeId()));
+      person
+          .getDocuments()
+          .add(
+              Document.builder()
+                  .documentNumber(request.documentNumber())
+                  .documentType(documentType)
+                  .person(person)
+                  .build());
       personRepository.save(person);
     }
 

--- a/src/main/java/com/caffeine/acs_backend/service/PersonService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/PersonService.java
@@ -41,8 +41,13 @@ public class PersonService {
             .build();
     personRepository.save(person);
 
-    if (request.documentNumber() != null && !request.documentNumber().isBlank()
-        && request.documentTypeId() != null) {
+    boolean hasDocumentNumber = request.documentNumber() != null && !request.documentNumber().isBlank();
+    boolean hasDocumentTypeId = request.documentTypeId() != null;
+    if (hasDocumentNumber != hasDocumentTypeId) {
+      throw new IllegalArgumentException(
+          "documentNumber and documentTypeId must both be provided together");
+    }
+    if (hasDocumentNumber) {
       DocumentType documentType =
           documentTypeRepository
               .findById(request.documentTypeId())

--- a/src/main/java/com/caffeine/acs_backend/service/VisitService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/VisitService.java
@@ -36,7 +36,9 @@ public class VisitService {
         accessPointRepository
             .findById(request.accessPointId())
             .orElseThrow(
-                () -> new IllegalArgumentException("Access point not found: " + request.accessPointId()));
+                () ->
+                    new IllegalArgumentException(
+                        "Access point not found: " + request.accessPointId()));
 
     Keycard keycard =
         keycardRepository
@@ -60,7 +62,9 @@ public class VisitService {
           personInRoleRepository
               .findById(request.hostPersonInRoleId())
               .orElseThrow(
-                  () -> new IllegalArgumentException("Host not found: " + request.hostPersonInRoleId()));
+                  () ->
+                      new IllegalArgumentException(
+                          "Host not found: " + request.hostPersonInRoleId()));
     }
 
     Role visitorRole =

--- a/src/main/java/com/caffeine/acs_backend/service/VisitService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/VisitService.java
@@ -1,0 +1,127 @@
+package com.caffeine.acs_backend.service;
+
+import com.caffeine.acs_backend.dto.visit.CreateVisitRequest;
+import com.caffeine.acs_backend.dto.visit.CreateVisitResponse;
+import com.caffeine.acs_backend.entity.*;
+import com.caffeine.acs_backend.repository.*;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class VisitService {
+
+  private static final String VISITOR_ROLE_NAME = "VISITOR";
+
+  private final AccessPointRepository accessPointRepository;
+  private final PersonInRoleRepository personInRoleRepository;
+  private final KeycardRepository keycardRepository;
+  private final KeycardInPossessionRepository keycardInPossessionRepository;
+  private final RoleRepository roleRepository;
+  private final PersonRepository personRepository;
+  private final VisitRepository visitRepository;
+
+  @Transactional
+  public CreateVisitResponse createVisit(CreateVisitRequest request, User assignorUser) {
+
+    Person person =
+        personRepository
+            .findById(request.personId())
+            .orElseThrow(
+                () -> new IllegalArgumentException("Person not found: " + request.personId()));
+
+    AccessPoint accessPoint =
+        accessPointRepository
+            .findById(request.accessPointId())
+            .orElseThrow(
+                () -> new IllegalArgumentException("Access point not found: " + request.accessPointId()));
+
+    Keycard keycard =
+        keycardRepository
+            .findById(request.keycardId())
+            .orElseThrow(
+                () -> new IllegalArgumentException("Keycard not found: " + request.keycardId()));
+
+    if (!keycard.isActive()) {
+      throw new IllegalArgumentException("Keycard is not active: " + request.keycardId());
+    }
+    if (keycardInPossessionRepository.existsByKeycardAndReturnTimeIsNull(keycard)) {
+      throw new IllegalArgumentException(
+          "Keycard is already assigned to someone: " + keycard.getKeycardNumber());
+    }
+
+    PersonInRole assignor = resolveAssignor(assignorUser);
+
+    PersonInRole host = null;
+    if (request.hostPersonInRoleId() != null) {
+      host =
+          personInRoleRepository
+              .findById(request.hostPersonInRoleId())
+              .orElseThrow(
+                  () -> new IllegalArgumentException("Host not found: " + request.hostPersonInRoleId()));
+    }
+
+    Role visitorRole =
+        roleRepository
+            .findByName(VISITOR_ROLE_NAME)
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "VISITOR role not configured in database. Please seed the roles table."));
+
+    PersonInRole visitorPersonInRole =
+        personInRoleRepository
+            .findByPersonAndRoleAndIsActiveTrue(person, visitorRole)
+            .orElseGet(
+                () ->
+                    personInRoleRepository.save(
+                        PersonInRole.builder().person(person).role(visitorRole).build()));
+
+    LocalDateTime now = request.arrivalTime() != null ? request.arrivalTime() : LocalDateTime.now();
+
+    Visit visit =
+        Visit.builder()
+            .arrivalTime(now)
+            .accessPoint(accessPoint)
+            .visitor(visitorPersonInRole)
+            .assignor(assignor)
+            .host(host)
+            .comment(request.comment())
+            .build();
+    visitRepository.save(visit);
+
+    KeycardInPossession possession =
+        KeycardInPossession.builder()
+            .keycard(keycard)
+            .assignedTime(now)
+            .keycardHolder(visitorPersonInRole)
+            .keycardAssignor(assignor)
+            .assigningAccessPoint(accessPoint)
+            .build();
+    keycardInPossessionRepository.save(possession);
+
+    return new CreateVisitResponse(
+        visit.getId(),
+        person.getId(),
+        visitorPersonInRole.getId(),
+        possession.getId(),
+        keycard.getKeycardNumber(),
+        now);
+  }
+
+  private PersonInRole resolveAssignor(User assignorUser) {
+    if (assignorUser.getPerson() == null) {
+      throw new IllegalStateException(
+          "Your user account has no linked Person. Ask an administrator to link your profile.");
+    }
+    return personInRoleRepository
+        .findFirstByPersonAndIsActiveTrue(assignorUser.getPerson())
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "No active role assignment found for your account."
+                        + " Ask an administrator to assign you a role."));
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/service/VisitService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/VisitService.java
@@ -46,8 +46,7 @@ public class VisitService {
           keycardRepository
               .findById(request.keycardId())
               .orElseThrow(
-                  () ->
-                      new IllegalArgumentException("Keycard not found: " + request.keycardId()));
+                  () -> new IllegalArgumentException("Keycard not found: " + request.keycardId()));
 
       if (!keycard.isActive()) {
         throw new IllegalArgumentException("Keycard is not active: " + request.keycardId());

--- a/src/main/java/com/caffeine/acs_backend/service/VisitService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/VisitService.java
@@ -40,18 +40,22 @@ public class VisitService {
                     new IllegalArgumentException(
                         "Access point not found: " + request.accessPointId()));
 
-    Keycard keycard =
-        keycardRepository
-            .findById(request.keycardId())
-            .orElseThrow(
-                () -> new IllegalArgumentException("Keycard not found: " + request.keycardId()));
+    Keycard keycard = null;
+    if (request.keycardId() != null) {
+      keycard =
+          keycardRepository
+              .findById(request.keycardId())
+              .orElseThrow(
+                  () ->
+                      new IllegalArgumentException("Keycard not found: " + request.keycardId()));
 
-    if (!keycard.isActive()) {
-      throw new IllegalArgumentException("Keycard is not active: " + request.keycardId());
-    }
-    if (keycardInPossessionRepository.existsByKeycardAndReturnTimeIsNull(keycard)) {
-      throw new IllegalArgumentException(
-          "Keycard is already assigned to someone: " + keycard.getKeycardNumber());
+      if (!keycard.isActive()) {
+        throw new IllegalArgumentException("Keycard is not active: " + request.keycardId());
+      }
+      if (keycardInPossessionRepository.existsByKeycardAndReturnTimeIsNull(keycard)) {
+        throw new IllegalArgumentException(
+            "Keycard is already assigned to someone: " + keycard.getKeycardNumber());
+      }
     }
 
     PersonInRole assignor = resolveAssignor(assignorUser);
@@ -96,22 +100,25 @@ public class VisitService {
             .build();
     visitRepository.save(visit);
 
-    KeycardInPossession possession =
-        KeycardInPossession.builder()
-            .keycard(keycard)
-            .assignedTime(now)
-            .keycardHolder(visitorPersonInRole)
-            .keycardAssignor(assignor)
-            .assigningAccessPoint(accessPoint)
-            .build();
-    keycardInPossessionRepository.save(possession);
+    KeycardInPossession possession = null;
+    if (keycard != null) {
+      possession =
+          KeycardInPossession.builder()
+              .keycard(keycard)
+              .assignedTime(now)
+              .keycardHolder(visitorPersonInRole)
+              .keycardAssignor(assignor)
+              .assigningAccessPoint(accessPoint)
+              .build();
+      keycardInPossessionRepository.save(possession);
+    }
 
     return new CreateVisitResponse(
         visit.getId(),
         person.getId(),
         visitorPersonInRole.getId(),
-        possession.getId(),
-        keycard.getKeycardNumber(),
+        possession != null ? possession.getId() : null,
+        keycard != null ? keycard.getKeycardNumber() : null,
         now);
   }
 


### PR DESCRIPTION
Changed this around. Should be Add visit instead of Add visitor.

<img width="753" height="738" alt="image" src="https://github.com/user-attachments/assets/ee3cc476-106c-412f-afbf-57815917341b" />

Because we mostly want to track visits. And also one visitor can visit many times, this does not mean we will have to do separate profile for him every time we visit. So rather the action should be Add visit instead. Inside that we should verify if user exists on our system, if yes, then use existing profile. If user does not exist on our system, then we should create one and then associate it with visit.

What endpoints and flow was added:
- Get Access points
- Get Available Key cards
- Get nationalities available in our system
- Search for persons in our system
- Create person in our system
- Create visit