### PR TITLE
feature/31 keycard inventory management related API endpoint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint and Format Check
+name: Lint, Format Check and Tests
 
 on:
   pull_request:
@@ -29,3 +29,6 @@ jobs:
         with:
           dockerfile: "**/Dockerfile*"
           recursive: true
+
+      - name: Run tests
+        run: ./mvnw --no-transfer-progress test

--- a/src/main/java/com/caffeine/acs_backend/controller/KeycardController.java
+++ b/src/main/java/com/caffeine/acs_backend/controller/KeycardController.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -28,16 +29,24 @@ import org.springframework.web.bind.annotation.*;
 @SecurityRequirement(name = "bearerAuth")
 public class KeycardController {
 
+  private static final String ADMIN_OR_SECURITY_CHIEF =
+      "hasAnyRole('ADMIN', 'SECURITY_CHIEF')";
+  private static final String ADMIN_SECURITY_CHIEF_OR_RECEPTIONIST =
+      "hasAnyRole('ADMIN', 'SECURITY_CHIEF', 'RECEPTIONIST')";
+
   private final KeycardService keycardService;
 
   @Operation(
       summary = "List keycards",
       description =
           "Returns a paginated list of keycards. Filter by status (available, in_use, disabled)."
-              + " Search by card number, holder name, or department.")
+              + " Search by card number, holder name, or department."
+              + " Accessible by Admin, Security Chief, and Receptionist.")
   @ApiResponse(responseCode = "200", description = "Keycard list returned")
   @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "403", description = "Forbidden")
   @GetMapping
+  @PreAuthorize(ADMIN_SECURITY_CHIEF_OR_RECEPTIONIST)
   public ResponseEntity<Page<KeycardListItemResponse>> getKeycards(
       @RequestParam(required = false) String search,
       @RequestParam(required = false) String status,
@@ -47,22 +56,30 @@ public class KeycardController {
 
   @Operation(
       summary = "Get keycard details",
-      description = "Returns full details for a single keycard.")
+      description =
+          "Returns full details for a single keycard."
+              + " Accessible by Admin, Security Chief, and Receptionist.")
   @ApiResponse(responseCode = "200", description = "Keycard returned")
   @ApiResponse(responseCode = "404", description = "Keycard not found")
   @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "403", description = "Forbidden")
   @GetMapping("/{cardId}")
+  @PreAuthorize(ADMIN_SECURITY_CHIEF_OR_RECEPTIONIST)
   public ResponseEntity<KeycardDetailResponse> getKeycard(@PathVariable UUID cardId) {
     return ResponseEntity.ok(keycardService.getKeycard(cardId));
   }
 
   @Operation(
       summary = "Register new keycard",
-      description = "Registers a new RFID keycard in the system.")
+      description =
+          "Registers a new RFID keycard in the system."
+              + " Accessible by Admin and Security Chief only.")
   @ApiResponse(responseCode = "201", description = "Keycard created")
   @ApiResponse(responseCode = "409", description = "Keycard number already exists")
   @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "403", description = "Forbidden")
   @PostMapping
+  @PreAuthorize(ADMIN_OR_SECURITY_CHIEF)
   public ResponseEntity<KeycardDetailResponse> createKeycard(
       @Valid @RequestBody CreateKeycardRequest request) {
     return ResponseEntity.status(HttpStatus.CREATED).body(keycardService.createKeycard(request));
@@ -70,11 +87,15 @@ public class KeycardController {
 
   @Operation(
       summary = "Update keycard",
-      description = "Updates keycard metadata — number, active status, or expiry.")
+      description =
+          "Updates keycard metadata — number, active status, or expiry."
+              + " Accessible by Admin and Security Chief only.")
   @ApiResponse(responseCode = "200", description = "Keycard updated")
   @ApiResponse(responseCode = "404", description = "Keycard not found")
   @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "403", description = "Forbidden")
   @PutMapping("/{cardId}")
+  @PreAuthorize(ADMIN_OR_SECURITY_CHIEF)
   public ResponseEntity<KeycardDetailResponse> updateKeycard(
       @PathVariable UUID cardId, @Valid @RequestBody UpdateKeycardRequest request) {
     return ResponseEntity.ok(keycardService.updateKeycard(cardId, request));
@@ -82,12 +103,16 @@ public class KeycardController {
 
   @Operation(
       summary = "Assign keycard",
-      description = "Issues a keycard to a person. Records the holder, assignor, and access point.")
+      description =
+          "Issues a keycard to a person. Records the holder, assignor, and access point."
+              + " Accessible by Admin, Security Chief, and Receptionist.")
   @ApiResponse(responseCode = "200", description = "Keycard assigned")
   @ApiResponse(responseCode = "404", description = "Keycard, person, or access point not found")
   @ApiResponse(responseCode = "409", description = "Keycard already assigned or not active")
   @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "403", description = "Forbidden")
   @PostMapping("/{cardId}/assign")
+  @PreAuthorize(ADMIN_SECURITY_CHIEF_OR_RECEPTIONIST)
   public ResponseEntity<KeycardDetailResponse> assignKeycard(
       @PathVariable UUID cardId, @Valid @RequestBody AssignKeycardRequest request) {
     return ResponseEntity.ok(keycardService.assignKeycard(cardId, request));
@@ -96,12 +121,15 @@ public class KeycardController {
   @Operation(
       summary = "Return keycard",
       description =
-          "Marks a keycard as returned. Records the return access point and current time.")
+          "Marks a keycard as returned. Records the return access point and current time."
+              + " Accessible by Admin, Security Chief, and Receptionist.")
   @ApiResponse(responseCode = "200", description = "Keycard returned")
   @ApiResponse(responseCode = "404", description = "Keycard or access point not found")
   @ApiResponse(responseCode = "409", description = "Keycard is not currently assigned")
   @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "403", description = "Forbidden")
   @PostMapping("/{cardId}/return")
+  @PreAuthorize(ADMIN_SECURITY_CHIEF_OR_RECEPTIONIST)
   public ResponseEntity<KeycardDetailResponse> returnKeycard(
       @PathVariable UUID cardId, @Valid @RequestBody ReturnKeycardRequest request) {
     return ResponseEntity.ok(keycardService.returnKeycard(cardId, request));

--- a/src/main/java/com/caffeine/acs_backend/controller/KeycardController.java
+++ b/src/main/java/com/caffeine/acs_backend/controller/KeycardController.java
@@ -1,34 +1,109 @@
 package com.caffeine.acs_backend.controller;
 
-import com.caffeine.acs_backend.dto.keycard.KeycardResponse;
+import com.caffeine.acs_backend.dto.keycard.AssignKeycardRequest;
+import com.caffeine.acs_backend.dto.keycard.CreateKeycardRequest;
+import com.caffeine.acs_backend.dto.keycard.KeycardDetailResponse;
+import com.caffeine.acs_backend.dto.keycard.KeycardListItemResponse;
+import com.caffeine.acs_backend.dto.keycard.ReturnKeycardRequest;
+import com.caffeine.acs_backend.dto.keycard.UpdateKeycardRequest;
 import com.caffeine.acs_backend.service.KeycardService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
+import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/keycards")
 @RequiredArgsConstructor
-@Tag(name = "Keycards", description = "Keycard management")
+@Tag(name = "Keycards", description = "Keycard inventory and assignment management")
 @SecurityRequirement(name = "bearerAuth")
 public class KeycardController {
 
   private final KeycardService keycardService;
 
   @Operation(
-      summary = "List available keycards",
-      description = "Returns all active keycards that are not currently assigned to anyone.")
-  @ApiResponse(responseCode = "200", description = "Available keycard list returned")
+      summary = "List keycards",
+      description =
+          "Returns a paginated list of keycards. Filter by status (available, in_use, disabled)."
+              + " Search by card number, holder name, or department.")
+  @ApiResponse(responseCode = "200", description = "Keycard list returned")
   @ApiResponse(responseCode = "401", description = "Unauthorized")
-  @GetMapping("/available")
-  public ResponseEntity<List<KeycardResponse>> getAvailableKeycards() {
-    return ResponseEntity.ok(keycardService.getAvailableKeycards());
+  @GetMapping
+  public ResponseEntity<Page<KeycardListItemResponse>> getKeycards(
+      @RequestParam(required = false) String search,
+      @RequestParam(required = false) String status,
+      @PageableDefault(size = 20) Pageable pageable) {
+    return ResponseEntity.ok(keycardService.getKeycards(search, status, pageable));
+  }
+
+  @Operation(
+      summary = "Get keycard details",
+      description = "Returns full details for a single keycard.")
+  @ApiResponse(responseCode = "200", description = "Keycard returned")
+  @ApiResponse(responseCode = "404", description = "Keycard not found")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @GetMapping("/{cardId}")
+  public ResponseEntity<KeycardDetailResponse> getKeycard(@PathVariable UUID cardId) {
+    return ResponseEntity.ok(keycardService.getKeycard(cardId));
+  }
+
+  @Operation(
+      summary = "Register new keycard",
+      description = "Registers a new RFID keycard in the system.")
+  @ApiResponse(responseCode = "201", description = "Keycard created")
+  @ApiResponse(responseCode = "409", description = "Keycard number already exists")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @PostMapping
+  public ResponseEntity<KeycardDetailResponse> createKeycard(
+      @Valid @RequestBody CreateKeycardRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED).body(keycardService.createKeycard(request));
+  }
+
+  @Operation(
+      summary = "Update keycard",
+      description = "Updates keycard metadata — number, active status, or expiry.")
+  @ApiResponse(responseCode = "200", description = "Keycard updated")
+  @ApiResponse(responseCode = "404", description = "Keycard not found")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @PutMapping("/{cardId}")
+  public ResponseEntity<KeycardDetailResponse> updateKeycard(
+      @PathVariable UUID cardId, @Valid @RequestBody UpdateKeycardRequest request) {
+    return ResponseEntity.ok(keycardService.updateKeycard(cardId, request));
+  }
+
+  @Operation(
+      summary = "Assign keycard",
+      description = "Issues a keycard to a person. Records the holder, assignor, and access point.")
+  @ApiResponse(responseCode = "200", description = "Keycard assigned")
+  @ApiResponse(responseCode = "404", description = "Keycard, person, or access point not found")
+  @ApiResponse(responseCode = "409", description = "Keycard already assigned or not active")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @PostMapping("/{cardId}/assign")
+  public ResponseEntity<KeycardDetailResponse> assignKeycard(
+      @PathVariable UUID cardId, @Valid @RequestBody AssignKeycardRequest request) {
+    return ResponseEntity.ok(keycardService.assignKeycard(cardId, request));
+  }
+
+  @Operation(
+      summary = "Return keycard",
+      description =
+          "Marks a keycard as returned. Records the return access point and current time.")
+  @ApiResponse(responseCode = "200", description = "Keycard returned")
+  @ApiResponse(responseCode = "404", description = "Keycard or access point not found")
+  @ApiResponse(responseCode = "409", description = "Keycard is not currently assigned")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @PostMapping("/{cardId}/return")
+  public ResponseEntity<KeycardDetailResponse> returnKeycard(
+      @PathVariable UUID cardId, @Valid @RequestBody ReturnKeycardRequest request) {
+    return ResponseEntity.ok(keycardService.returnKeycard(cardId, request));
   }
 }

--- a/src/main/java/com/caffeine/acs_backend/controller/KeycardController.java
+++ b/src/main/java/com/caffeine/acs_backend/controller/KeycardController.java
@@ -29,8 +29,7 @@ import org.springframework.web.bind.annotation.*;
 @SecurityRequirement(name = "bearerAuth")
 public class KeycardController {
 
-  private static final String ADMIN_OR_SECURITY_CHIEF =
-      "hasAnyRole('ADMIN', 'SECURITY_CHIEF')";
+  private static final String ADMIN_OR_SECURITY_CHIEF = "hasAnyRole('ADMIN', 'SECURITY_CHIEF')";
   private static final String ADMIN_SECURITY_CHIEF_OR_RECEPTIONIST =
       "hasAnyRole('ADMIN', 'SECURITY_CHIEF', 'RECEPTIONIST')";
 

--- a/src/main/java/com/caffeine/acs_backend/dto/keycard/AssignKeycardRequest.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/keycard/AssignKeycardRequest.java
@@ -1,0 +1,14 @@
+package com.caffeine.acs_backend.dto.keycard;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+@Schema(description = "Request body for issuing a keycard to a person")
+public record AssignKeycardRequest(
+    @Schema(description = "PersonInRole ID of the person receiving the card") @NotNull
+        UUID keycardHolderPersonInRoleId,
+    @Schema(description = "PersonInRole ID of the staff member issuing the card") @NotNull
+        UUID keycardAssignorPersonInRoleId,
+    @Schema(description = "Access point ID where the card is being issued") @NotNull
+        UUID assigningAccessPointId) {}

--- a/src/main/java/com/caffeine/acs_backend/dto/keycard/CreateKeycardRequest.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/keycard/CreateKeycardRequest.java
@@ -1,0 +1,15 @@
+package com.caffeine.acs_backend.dto.keycard;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+@Schema(description = "Request body for registering a new RFID keycard")
+public record CreateKeycardRequest(
+    @Schema(description = "Keycard number printed on the card", example = "KC-0042")
+        @NotBlank
+        @Size(max = 128)
+        String keycardNumber,
+    @Schema(description = "Expiration date/time, omit for no expiry") LocalDateTime validUntil,
+    @Schema(description = "Initial active status", example = "true") boolean initialStatus) {}

--- a/src/main/java/com/caffeine/acs_backend/dto/keycard/KeycardDetailResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/keycard/KeycardDetailResponse.java
@@ -1,0 +1,46 @@
+package com.caffeine.acs_backend.dto.keycard;
+
+import com.caffeine.acs_backend.entity.Keycard;
+import com.caffeine.acs_backend.entity.KeycardInPossession;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(description = "Full keycard details")
+public record KeycardDetailResponse(
+    @Schema(description = "Unique identifier") UUID id,
+    @Schema(description = "Keycard number printed on the card", example = "KC-0001")
+        String keycardNumber,
+    @Schema(description = "Whether the keycard is active") boolean active,
+    @Schema(description = "Expiration date/time, null means no expiry") LocalDateTime validUntil,
+    @Schema(description = "Full name of the person currently holding the card, null if available")
+        String assignedUser,
+    @Schema(description = "UUID of the active person_in_role holding the card")
+        UUID assignedPersonInRoleId,
+    @Schema(description = "When the card was assigned to the current holder")
+        LocalDateTime assignedTime,
+    @Schema(description = "When the card was last returned, null if never returned")
+        LocalDateTime lastReturnTime) {
+
+  public static KeycardDetailResponse from(
+      Keycard keycard, KeycardInPossession activePossession, LocalDateTime lastReturnTime) {
+    String assignedUser = null;
+    UUID assignedPersonInRoleId = null;
+    LocalDateTime assignedTime = null;
+    if (activePossession != null) {
+      var person = activePossession.getKeycardHolder().getPerson();
+      assignedUser = person.getGivenName() + " " + person.getSurname();
+      assignedPersonInRoleId = activePossession.getKeycardHolder().getId();
+      assignedTime = activePossession.getAssignedTime();
+    }
+    return new KeycardDetailResponse(
+        keycard.getId(),
+        keycard.getKeycardNumber(),
+        keycard.isActive(),
+        keycard.getValidUntil(),
+        assignedUser,
+        assignedPersonInRoleId,
+        assignedTime,
+        lastReturnTime);
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/dto/keycard/KeycardListItemResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/keycard/KeycardListItemResponse.java
@@ -1,0 +1,30 @@
+package com.caffeine.acs_backend.dto.keycard;
+
+import com.caffeine.acs_backend.repository.KeycardListView;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(description = "Keycard summary for paginated list view")
+public record KeycardListItemResponse(
+    @Schema(description = "Unique identifier") UUID id,
+    @Schema(description = "Keycard number printed on the card", example = "KC-0001")
+        String keycardNumber,
+    @Schema(description = "Status: AVAILABLE, IN_USE, DISABLED, or EXPIRED", example = "AVAILABLE")
+        String status,
+    @Schema(
+            description = "Full name of the person currently holding the card, null if not in use",
+            example = "John Smith")
+        String assignedUser,
+    @Schema(description = "When the card was last returned, null if never returned")
+        LocalDateTime lastReturnTime) {
+
+  public static KeycardListItemResponse from(KeycardListView view) {
+    return new KeycardListItemResponse(
+        view.getId(),
+        view.getKeycardNumber(),
+        view.getStatus(),
+        view.getAssignedUser(),
+        view.getLastReturnTime());
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/dto/keycard/ReturnKeycardRequest.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/keycard/ReturnKeycardRequest.java
@@ -1,0 +1,10 @@
+package com.caffeine.acs_backend.dto.keycard;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+@Schema(description = "Request body for returning a keycard")
+public record ReturnKeycardRequest(
+    @Schema(description = "Access point ID where the card is being returned") @NotNull
+        UUID returnAccessPointId) {}

--- a/src/main/java/com/caffeine/acs_backend/dto/keycard/UpdateKeycardRequest.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/keycard/UpdateKeycardRequest.java
@@ -1,0 +1,14 @@
+package com.caffeine.acs_backend.dto.keycard;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+@Schema(description = "Request body for updating keycard metadata")
+public record UpdateKeycardRequest(
+    @Schema(description = "Updated keycard number", example = "KC-0042") @Size(max = 128)
+        String keycardNumber,
+    @Schema(description = "Updated active status — set false to deactivate (lost/stolen)")
+        Boolean active,
+    @Schema(description = "Updated expiration date/time, null clears the expiry")
+        LocalDateTime validUntil) {}

--- a/src/main/java/com/caffeine/acs_backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/caffeine/acs_backend/exception/GlobalExceptionHandler.java
@@ -69,6 +69,23 @@ public class GlobalExceptionHandler {
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
   }
 
+  // --- 403: Method-level access denied (@PreAuthorize) ---
+  @ExceptionHandler(org.springframework.security.access.AccessDeniedException.class)
+  public ResponseEntity<ErrorResponse> handleAccessDenied(
+      org.springframework.security.access.AccessDeniedException ex, HttpServletRequest request) {
+    ErrorResponse body =
+        ErrorResponse.builder()
+            .timestamp(Instant.now())
+            .message("Access denied")
+            .status(HttpStatus.FORBIDDEN.value())
+            .errorCode(ErrorCode.ACCESS_DENIED)
+            .path(request.getRequestURI())
+            .details(null)
+            .build();
+
+    return ResponseEntity.status(HttpStatus.FORBIDDEN).body(body);
+  }
+
   // --- BusinessException ---
   @ExceptionHandler(BusinessException.class)
   public ResponseEntity<ErrorResponse> handleBusiness(

--- a/src/main/java/com/caffeine/acs_backend/repository/KeycardInPossessionRepository.java
+++ b/src/main/java/com/caffeine/acs_backend/repository/KeycardInPossessionRepository.java
@@ -2,10 +2,30 @@ package com.caffeine.acs_backend.repository;
 
 import com.caffeine.acs_backend.entity.Keycard;
 import com.caffeine.acs_backend.entity.KeycardInPossession;
+import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface KeycardInPossessionRepository extends JpaRepository<KeycardInPossession, UUID> {
 
   boolean existsByKeycardAndReturnTimeIsNull(Keycard keycard);
+
+  @Query(
+      "SELECT kp FROM KeycardInPossession kp"
+          + " JOIN FETCH kp.keycardHolder holder"
+          + " JOIN FETCH holder.person"
+          + " WHERE kp.keycard = :keycard AND kp.returnTime IS NULL")
+  Optional<KeycardInPossession> findActiveByKeycard(@Param("keycard") Keycard keycard);
+
+  @Query(
+      "SELECT kp FROM KeycardInPossession kp"
+          + " JOIN FETCH kp.keycardHolder holder"
+          + " JOIN FETCH holder.person"
+          + " WHERE kp.keycard = :keycard"
+          + " ORDER BY kp.assignedTime DESC")
+  java.util.List<KeycardInPossession> findLatestByKeycard(
+      @Param("keycard") Keycard keycard, Pageable pageable);
 }

--- a/src/main/java/com/caffeine/acs_backend/repository/KeycardListView.java
+++ b/src/main/java/com/caffeine/acs_backend/repository/KeycardListView.java
@@ -1,0 +1,21 @@
+package com.caffeine.acs_backend.repository;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/** Spring Data projection interface for the native keycard list query. */
+public interface KeycardListView {
+
+  UUID getId();
+
+  String getKeycardNumber();
+
+  /** Computed status: AVAILABLE, IN_USE, DISABLED, or EXPIRED. */
+  String getStatus();
+
+  /** Full name of the current holder, null when card is not in use. */
+  String getAssignedUser();
+
+  /** Most recent return time across all possessions, null if never returned. */
+  LocalDateTime getLastReturnTime();
+}

--- a/src/main/java/com/caffeine/acs_backend/repository/KeycardRepository.java
+++ b/src/main/java/com/caffeine/acs_backend/repository/KeycardRepository.java
@@ -1,19 +1,83 @@
 package com.caffeine.acs_backend.repository;
 
 import com.caffeine.acs_backend.entity.Keycard;
-import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface KeycardRepository extends JpaRepository<Keycard, UUID> {
 
+  boolean existsByKeycardNumber(String keycardNumber);
+
   @Query(
-      "SELECT k FROM Keycard k WHERE k.isActive = true"
-          + " AND (k.validUntil IS NULL OR k.validUntil > CURRENT_TIMESTAMP)"
-          + " AND NOT EXISTS ("
-          + "   SELECT 1 FROM KeycardInPossession kp"
-          + "   WHERE kp.keycard = k AND kp.returnTime IS NULL"
-          + " )")
-  List<Keycard> findAvailableKeycards();
+      nativeQuery = true,
+      value =
+          "SELECT"
+              + "  k.id                          AS \"id\","
+              + "  k.keycard_number              AS \"keycardNumber\","
+              + "  CASE"
+              + "    WHEN NOT k.is_active                                         THEN 'DISABLED'"
+              + "    WHEN k.valid_until IS NOT NULL AND k.valid_until < NOW()     THEN 'EXPIRED'"
+              + "    WHEN kip.id IS NOT NULL                                      THEN 'IN_USE'"
+              + "    ELSE 'AVAILABLE'"
+              + "  END                           AS \"status\","
+              + "  CASE WHEN kip.id IS NOT NULL"
+              + "    THEN p.given_name || ' ' || p.surname"
+              + "    ELSE NULL"
+              + "  END                           AS \"assignedUser\","
+              + "  (SELECT MAX(kip2.return_time)"
+              + "   FROM keycard_in_possession kip2"
+              + "   WHERE kip2.keycard_id = k.id) AS \"lastReturnTime\""
+              + " FROM keycard k"
+              + " LEFT JOIN keycard_in_possession kip"
+              + "        ON kip.keycard_id = k.id AND kip.return_time IS NULL"
+              + " LEFT JOIN person_in_role pir"
+              + "        ON pir.id = kip.keycard_holder_person_in_role_id"
+              + " LEFT JOIN person p ON p.id = pir.person_id"
+              + " WHERE"
+              + "   ( CAST(:search AS text) IS NULL"
+              + "     OR k.keycard_number ILIKE '%' || :search || '%'"
+              + "     OR (p.given_name || ' ' || p.surname) ILIKE '%' || :search || '%'"
+              + "   )"
+              + "   AND"
+              + "   ( CAST(:status AS text) IS NULL"
+              + "     OR (:status = 'disabled' AND NOT k.is_active)"
+              + "     OR (:status = 'expired'  AND k.is_active"
+              + "                               AND k.valid_until IS NOT NULL"
+              + "                               AND k.valid_until < NOW())"
+              + "     OR (:status = 'in_use'   AND kip.id IS NOT NULL)"
+              + "     OR (:status = 'available' AND k.is_active"
+              + "                                AND (k.valid_until IS NULL OR k.valid_until >= NOW())"
+              + "                                AND kip.id IS NULL)"
+              + "   )"
+              + " ORDER BY k.keycard_number",
+      countQuery =
+          "SELECT COUNT(*)"
+              + " FROM keycard k"
+              + " LEFT JOIN keycard_in_possession kip"
+              + "        ON kip.keycard_id = k.id AND kip.return_time IS NULL"
+              + " LEFT JOIN person_in_role pir"
+              + "        ON pir.id = kip.keycard_holder_person_in_role_id"
+              + " LEFT JOIN person p ON p.id = pir.person_id"
+              + " WHERE"
+              + "   ( CAST(:search AS text) IS NULL"
+              + "     OR k.keycard_number ILIKE '%' || :search || '%'"
+              + "     OR (p.given_name || ' ' || p.surname) ILIKE '%' || :search || '%'"
+              + "   )"
+              + "   AND"
+              + "   ( CAST(:status AS text) IS NULL"
+              + "     OR (:status = 'disabled' AND NOT k.is_active)"
+              + "     OR (:status = 'expired'  AND k.is_active"
+              + "                               AND k.valid_until IS NOT NULL"
+              + "                               AND k.valid_until < NOW())"
+              + "     OR (:status = 'in_use'   AND kip.id IS NOT NULL)"
+              + "     OR (:status = 'available' AND k.is_active"
+              + "                                AND (k.valid_until IS NULL OR k.valid_until >= NOW())"
+              + "                                AND kip.id IS NULL)"
+              + "   )")
+  Page<KeycardListView> findAllFiltered(
+      @Param("search") String search, @Param("status") String status, Pageable pageable);
 }

--- a/src/main/java/com/caffeine/acs_backend/security/SecurityConfig.java
+++ b/src/main/java/com/caffeine/acs_backend/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -15,7 +16,8 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
-@EnableWebSecurity // Tagab, et turvaseaded rakenduvad korrektselt
+@EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/com/caffeine/acs_backend/service/KeycardService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/KeycardService.java
@@ -1,18 +1,214 @@
 package com.caffeine.acs_backend.service;
 
-import com.caffeine.acs_backend.dto.keycard.KeycardResponse;
+import com.caffeine.acs_backend.dto.keycard.AssignKeycardRequest;
+import com.caffeine.acs_backend.dto.keycard.CreateKeycardRequest;
+import com.caffeine.acs_backend.dto.keycard.KeycardDetailResponse;
+import com.caffeine.acs_backend.dto.keycard.KeycardListItemResponse;
+import com.caffeine.acs_backend.dto.keycard.ReturnKeycardRequest;
+import com.caffeine.acs_backend.dto.keycard.UpdateKeycardRequest;
+import com.caffeine.acs_backend.entity.AccessPoint;
+import com.caffeine.acs_backend.entity.Keycard;
+import com.caffeine.acs_backend.entity.KeycardInPossession;
+import com.caffeine.acs_backend.entity.PersonInRole;
+import com.caffeine.acs_backend.enums.errorcode.ErrorCode;
+import com.caffeine.acs_backend.exception.BusinessException;
+import com.caffeine.acs_backend.repository.AccessPointRepository;
+import com.caffeine.acs_backend.repository.KeycardInPossessionRepository;
 import com.caffeine.acs_backend.repository.KeycardRepository;
-import java.util.List;
+import com.caffeine.acs_backend.repository.PersonInRoleRepository;
+import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class KeycardService {
 
   private final KeycardRepository keycardRepository;
+  private final KeycardInPossessionRepository keycardInPossessionRepository;
+  private final PersonInRoleRepository personInRoleRepository;
+  private final AccessPointRepository accessPointRepository;
 
-  public List<KeycardResponse> getAvailableKeycards() {
-    return keycardRepository.findAvailableKeycards().stream().map(KeycardResponse::from).toList();
+  @Transactional(readOnly = true)
+  public Page<KeycardListItemResponse> getKeycards(
+      String search, String status, Pageable pageable) {
+    String searchParam = (search == null || search.isBlank()) ? null : search.trim();
+    String statusParam = (status == null || status.isBlank()) ? null : status.trim().toLowerCase();
+    return keycardRepository
+        .findAllFiltered(searchParam, statusParam, pageable)
+        .map(KeycardListItemResponse::from);
+  }
+
+  @Transactional(readOnly = true)
+  public KeycardDetailResponse getKeycard(UUID id) {
+    Keycard keycard = findKeycardOrThrow(id);
+    KeycardInPossession active =
+        keycardInPossessionRepository.findActiveByKeycard(keycard).orElse(null);
+    LocalDateTime lastReturn = null;
+    if (active == null) {
+      lastReturn =
+          keycardInPossessionRepository
+              .findLatestByKeycard(keycard, PageRequest.of(0, 1))
+              .stream()
+              .findFirst()
+              .map(KeycardInPossession::getReturnTime)
+              .orElse(null);
+    }
+    return KeycardDetailResponse.from(keycard, active, lastReturn);
+  }
+
+  @Transactional
+  public KeycardDetailResponse createKeycard(CreateKeycardRequest request) {
+    if (keycardRepository.existsByKeycardNumber(request.keycardNumber())) {
+      throw new BusinessException(
+          "Keycard number already exists: " + request.keycardNumber(),
+          ErrorCode.RESOURCE_ALREADY_EXISTS,
+          HttpStatus.CONFLICT);
+    }
+    Keycard keycard =
+        Keycard.builder()
+            .keycardNumber(request.keycardNumber())
+            .validUntil(request.validUntil())
+            .isActive(request.initialStatus())
+            .build();
+    keycardRepository.save(keycard);
+    return KeycardDetailResponse.from(keycard, null, null);
+  }
+
+  @Transactional
+  public KeycardDetailResponse updateKeycard(UUID id, UpdateKeycardRequest request) {
+    Keycard keycard = findKeycardOrThrow(id);
+    if (request.keycardNumber() != null && !request.keycardNumber().isBlank()) {
+      keycard.setKeycardNumber(request.keycardNumber());
+    }
+    if (request.active() != null) {
+      keycard.setActive(request.active());
+    }
+    if (request.validUntil() != null) {
+      keycard.setValidUntil(request.validUntil());
+    }
+    keycardRepository.save(keycard);
+    KeycardInPossession active =
+        keycardInPossessionRepository.findActiveByKeycard(keycard).orElse(null);
+    LocalDateTime lastReturn = null;
+    if (active == null) {
+      lastReturn =
+          keycardInPossessionRepository
+              .findLatestByKeycard(keycard, PageRequest.of(0, 1))
+              .stream()
+              .findFirst()
+              .map(KeycardInPossession::getReturnTime)
+              .orElse(null);
+    }
+    return KeycardDetailResponse.from(keycard, active, lastReturn);
+  }
+
+  @Transactional
+  public KeycardDetailResponse assignKeycard(UUID id, AssignKeycardRequest request) {
+    Keycard keycard = findKeycardOrThrow(id);
+
+    if (!keycard.isActive()) {
+      throw new BusinessException(
+          "Keycard is not active", ErrorCode.BUSINESS_RULE_VIOLATION, HttpStatus.CONFLICT);
+    }
+    if (keycard.getValidUntil() != null && keycard.getValidUntil().isBefore(LocalDateTime.now())) {
+      throw new BusinessException(
+          "Keycard is expired", ErrorCode.BUSINESS_RULE_VIOLATION, HttpStatus.CONFLICT);
+    }
+    if (keycardInPossessionRepository.existsByKeycardAndReturnTimeIsNull(keycard)) {
+      throw new BusinessException(
+          "Keycard is already assigned", ErrorCode.BUSINESS_RULE_VIOLATION, HttpStatus.CONFLICT);
+    }
+
+    PersonInRole holder =
+        personInRoleRepository
+            .findById(request.keycardHolderPersonInRoleId())
+            .orElseThrow(
+                () ->
+                    new BusinessException(
+                        "Holder PersonInRole not found: " + request.keycardHolderPersonInRoleId(),
+                        ErrorCode.RESOURCE_NOT_FOUND,
+                        HttpStatus.NOT_FOUND));
+
+    PersonInRole assignor =
+        personInRoleRepository
+            .findById(request.keycardAssignorPersonInRoleId())
+            .orElseThrow(
+                () ->
+                    new BusinessException(
+                        "Assignor PersonInRole not found: "
+                            + request.keycardAssignorPersonInRoleId(),
+                        ErrorCode.RESOURCE_NOT_FOUND,
+                        HttpStatus.NOT_FOUND));
+
+    AccessPoint accessPoint =
+        accessPointRepository
+            .findById(request.assigningAccessPointId())
+            .orElseThrow(
+                () ->
+                    new BusinessException(
+                        "Access point not found: " + request.assigningAccessPointId(),
+                        ErrorCode.RESOURCE_NOT_FOUND,
+                        HttpStatus.NOT_FOUND));
+
+    KeycardInPossession possession =
+        KeycardInPossession.builder()
+            .keycard(keycard)
+            .keycardHolder(holder)
+            .keycardAssignor(assignor)
+            .assigningAccessPoint(accessPoint)
+            .assignedTime(LocalDateTime.now())
+            .build();
+    keycardInPossessionRepository.save(possession);
+
+    return KeycardDetailResponse.from(keycard, possession, null);
+  }
+
+  @Transactional
+  public KeycardDetailResponse returnKeycard(UUID id, ReturnKeycardRequest request) {
+    Keycard keycard = findKeycardOrThrow(id);
+
+    KeycardInPossession possession =
+        keycardInPossessionRepository
+            .findActiveByKeycard(keycard)
+            .orElseThrow(
+                () ->
+                    new BusinessException(
+                        "Keycard is not currently assigned",
+                        ErrorCode.BUSINESS_RULE_VIOLATION,
+                        HttpStatus.CONFLICT));
+
+    AccessPoint returnPoint =
+        accessPointRepository
+            .findById(request.returnAccessPointId())
+            .orElseThrow(
+                () ->
+                    new BusinessException(
+                        "Access point not found: " + request.returnAccessPointId(),
+                        ErrorCode.RESOURCE_NOT_FOUND,
+                        HttpStatus.NOT_FOUND));
+
+    possession.setReturnAccessPoint(returnPoint);
+    possession.setReturnTime(LocalDateTime.now());
+    keycardInPossessionRepository.save(possession);
+
+    return KeycardDetailResponse.from(keycard, null, possession.getReturnTime());
+  }
+
+  private Keycard findKeycardOrThrow(UUID id) {
+    return keycardRepository
+        .findById(id)
+        .orElseThrow(
+            () ->
+                new BusinessException(
+                    "Keycard not found: " + id,
+                    ErrorCode.RESOURCE_NOT_FOUND,
+                    HttpStatus.NOT_FOUND));
   }
 }

--- a/src/main/java/com/caffeine/acs_backend/service/KeycardService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/KeycardService.java
@@ -53,9 +53,7 @@ public class KeycardService {
     LocalDateTime lastReturn = null;
     if (active == null) {
       lastReturn =
-          keycardInPossessionRepository
-              .findLatestByKeycard(keycard, PageRequest.of(0, 1))
-              .stream()
+          keycardInPossessionRepository.findLatestByKeycard(keycard, PageRequest.of(0, 1)).stream()
               .findFirst()
               .map(KeycardInPossession::getReturnTime)
               .orElse(null);
@@ -99,9 +97,7 @@ public class KeycardService {
     LocalDateTime lastReturn = null;
     if (active == null) {
       lastReturn =
-          keycardInPossessionRepository
-              .findLatestByKeycard(keycard, PageRequest.of(0, 1))
-              .stream()
+          keycardInPossessionRepository.findLatestByKeycard(keycard, PageRequest.of(0, 1)).stream()
               .findFirst()
               .map(KeycardInPossession::getReturnTime)
               .orElse(null);

--- a/src/main/resources/db/changelog/changes/002-dev-seed-data.yaml
+++ b/src/main/resources/db/changelog/changes/002-dev-seed-data.yaml
@@ -354,7 +354,7 @@ databaseChangeLog:
               - column: { name: id, value: "a9000000-0000-0000-0000-000000000001" }
               - column: { name: email, value: "admin@dev.local" }
               # bcrypt hash of "password"
-              - column: { name: password, value: "$2b$10$7qsX1SPKh5QK9soqJm6CGupv25ALJYIqtOSGKewPcu7ti1EEqkjUa" }
+              - column: { name: password, value: "$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iKom4ZEpc/fVjCNqY9cqzPGGaFzm" }
               - column: { name: role, value: "ADMIN" }
               - column: { name: person_id, value: "a8000000-0000-0000-0000-000000000001" }
         - insert:
@@ -362,7 +362,7 @@ databaseChangeLog:
             columns:
               - column: { name: id, value: "a9000000-0000-0000-0000-000000000002" }
               - column: { name: email, value: "security@dev.local" }
-              - column: { name: password, value: "$2b$10$7qsX1SPKh5QK9soqJm6CGupv25ALJYIqtOSGKewPcu7ti1EEqkjUa" }
+              - column: { name: password, value: "$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iKom4ZEpc/fVjCNqY9cqzPGGaFzm" }
               - column: { name: role, value: "SECURITY_CHIEF" }
               - column: { name: person_id, value: "a8000000-0000-0000-0000-000000000002" }
         - insert:
@@ -370,7 +370,7 @@ databaseChangeLog:
             columns:
               - column: { name: id, value: "a9000000-0000-0000-0000-000000000003" }
               - column: { name: email, value: "receptionist@dev.local" }
-              - column: { name: password, value: "$2b$10$7qsX1SPKh5QK9soqJm6CGupv25ALJYIqtOSGKewPcu7ti1EEqkjUa" }
+              - column: { name: password, value: "$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iKom4ZEpc/fVjCNqY9cqzPGGaFzm" }
               - column: { name: role, value: "RECEPTIONIST" }
               - column: { name: person_id, value: "a8000000-0000-0000-0000-000000000003" }
         - insert:
@@ -378,7 +378,7 @@ databaseChangeLog:
             columns:
               - column: { name: id, value: "a9000000-0000-0000-0000-000000000004" }
               - column: { name: email, value: "visitor@dev.local" }
-              - column: { name: password, value: "$2b$10$7qsX1SPKh5QK9soqJm6CGupv25ALJYIqtOSGKewPcu7ti1EEqkjUa" }
+              - column: { name: password, value: "$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iKom4ZEpc/fVjCNqY9cqzPGGaFzm" }
               - column: { name: role, value: "VISITOR" }
               - column: { name: person_id, value: "a8000000-0000-0000-0000-000000000004" }
 

--- a/src/main/resources/db/changelog/changes/002-dev-seed-data.yaml
+++ b/src/main/resources/db/changelog/changes/002-dev-seed-data.yaml
@@ -354,7 +354,7 @@ databaseChangeLog:
               - column: { name: id, value: "a9000000-0000-0000-0000-000000000001" }
               - column: { name: email, value: "admin@dev.local" }
               # bcrypt hash of "password"
-              - column: { name: password, value: "$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iKom4ZEpc/fVjCNqY9cqzPGGaFzm" }
+              - column: { name: password, value: "$2b$10$7qsX1SPKh5QK9soqJm6CGupv25ALJYIqtOSGKewPcu7ti1EEqkjUa" }
               - column: { name: role, value: "ADMIN" }
               - column: { name: person_id, value: "a8000000-0000-0000-0000-000000000001" }
         - insert:
@@ -362,7 +362,7 @@ databaseChangeLog:
             columns:
               - column: { name: id, value: "a9000000-0000-0000-0000-000000000002" }
               - column: { name: email, value: "security@dev.local" }
-              - column: { name: password, value: "$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iKom4ZEpc/fVjCNqY9cqzPGGaFzm" }
+              - column: { name: password, value: "$2b$10$7qsX1SPKh5QK9soqJm6CGupv25ALJYIqtOSGKewPcu7ti1EEqkjUa" }
               - column: { name: role, value: "SECURITY_CHIEF" }
               - column: { name: person_id, value: "a8000000-0000-0000-0000-000000000002" }
         - insert:
@@ -370,7 +370,7 @@ databaseChangeLog:
             columns:
               - column: { name: id, value: "a9000000-0000-0000-0000-000000000003" }
               - column: { name: email, value: "receptionist@dev.local" }
-              - column: { name: password, value: "$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iKom4ZEpc/fVjCNqY9cqzPGGaFzm" }
+              - column: { name: password, value: "$2b$10$7qsX1SPKh5QK9soqJm6CGupv25ALJYIqtOSGKewPcu7ti1EEqkjUa" }
               - column: { name: role, value: "RECEPTIONIST" }
               - column: { name: person_id, value: "a8000000-0000-0000-0000-000000000003" }
         - insert:
@@ -378,7 +378,7 @@ databaseChangeLog:
             columns:
               - column: { name: id, value: "a9000000-0000-0000-0000-000000000004" }
               - column: { name: email, value: "visitor@dev.local" }
-              - column: { name: password, value: "$2a$10$N.zmdr9k7uOCQb376NoUnuTJ8iKom4ZEpc/fVjCNqY9cqzPGGaFzm" }
+              - column: { name: password, value: "$2b$10$7qsX1SPKh5QK9soqJm6CGupv25ALJYIqtOSGKewPcu7ti1EEqkjUa" }
               - column: { name: role, value: "VISITOR" }
               - column: { name: person_id, value: "a8000000-0000-0000-0000-000000000004" }
 

--- a/src/main/resources/db/changelog/changes/003-dev-fix-password-hashes.yaml
+++ b/src/main/resources/db/changelog/changes/003-dev-fix-password-hashes.yaml
@@ -1,0 +1,30 @@
+databaseChangeLog:
+  - changeSet:
+      id: 003-01-fix-app-user-password-hashes
+      author: dev
+      context: dev
+      comment: >
+        The original seed hash ($2a$10$N...) does not match "password" under Spring Security's
+        BCryptPasswordEncoder. Replace with a verified $2b$ hash so dev logins work out of the box.
+      changes:
+        - update:
+            tableName: app_user
+            columns:
+              # bcrypt hash of "password"
+              - column: { name: password, value: "$2b$10$7qsX1SPKh5QK9soqJm6CGupv25ALJYIqtOSGKewPcu7ti1EEqkjUa" }
+            where: "email = 'admin@dev.local'"
+        - update:
+            tableName: app_user
+            columns:
+              - column: { name: password, value: "$2b$10$7qsX1SPKh5QK9soqJm6CGupv25ALJYIqtOSGKewPcu7ti1EEqkjUa" }
+            where: "email = 'security@dev.local'"
+        - update:
+            tableName: app_user
+            columns:
+              - column: { name: password, value: "$2b$10$7qsX1SPKh5QK9soqJm6CGupv25ALJYIqtOSGKewPcu7ti1EEqkjUa" }
+            where: "email = 'receptionist@dev.local'"
+        - update:
+            tableName: app_user
+            columns:
+              - column: { name: password, value: "$2b$10$7qsX1SPKh5QK9soqJm6CGupv25ALJYIqtOSGKewPcu7ti1EEqkjUa" }
+            where: "email = 'visitor@dev.local'"

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3,3 +3,5 @@ databaseChangeLog:
       file: db/changelog/changes/001-initial-schema.yaml
   - include:
       file: db/changelog/changes/002-dev-seed-data.yaml
+  - include:
+      file: db/changelog/changes/003-dev-fix-password-hashes.yaml

--- a/src/test/java/com/caffeine/acs_backend/controller/KeycardControllerTest.java
+++ b/src/test/java/com/caffeine/acs_backend/controller/KeycardControllerTest.java
@@ -39,8 +39,12 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(KeycardController.class)
-@Import({SecurityConfig.class, JwtAuthFilter.class, JwtAccessDeniedHandler.class,
-    JwtAuthenticationEntryPoint.class})
+@Import({
+  SecurityConfig.class,
+  JwtAuthFilter.class,
+  JwtAccessDeniedHandler.class,
+  JwtAuthenticationEntryPoint.class
+})
 class KeycardControllerTest {
 
   @Autowired private MockMvc mockMvc;

--- a/src/test/java/com/caffeine/acs_backend/controller/KeycardControllerTest.java
+++ b/src/test/java/com/caffeine/acs_backend/controller/KeycardControllerTest.java
@@ -1,0 +1,319 @@
+package com.caffeine.acs_backend.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.caffeine.acs_backend.dto.keycard.AssignKeycardRequest;
+import com.caffeine.acs_backend.dto.keycard.CreateKeycardRequest;
+import com.caffeine.acs_backend.dto.keycard.KeycardDetailResponse;
+import com.caffeine.acs_backend.dto.keycard.KeycardListItemResponse;
+import com.caffeine.acs_backend.dto.keycard.ReturnKeycardRequest;
+import com.caffeine.acs_backend.dto.keycard.UpdateKeycardRequest;
+import com.caffeine.acs_backend.enums.errorcode.ErrorCode;
+import com.caffeine.acs_backend.exception.BusinessException;
+import com.caffeine.acs_backend.security.JwtAccessDeniedHandler;
+import com.caffeine.acs_backend.security.JwtAuthenticationEntryPoint;
+import com.caffeine.acs_backend.security.JwtService;
+import com.caffeine.acs_backend.service.KeycardService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(KeycardController.class)
+class KeycardControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+
+  @MockBean private KeycardService keycardService;
+
+  // Real SecurityConfig runs; mock all its injected dependencies
+  @MockBean private JwtService jwtService;
+  @MockBean private UserDetailsService userDetailsService;
+  @MockBean private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+  @MockBean private JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+  private static final UUID CARD_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+  private KeycardDetailResponse sampleDetail() {
+    return new KeycardDetailResponse(CARD_ID, "KC-0001", true, null, null, null, null, null);
+  }
+
+  // ── GET /api/keycards ────────────────────────────────────────────────────────
+
+  @Test
+  @WithMockUser
+  void getKeycards_noFilters_returns200WithPage() throws Exception {
+    KeycardListItemResponse item =
+        new KeycardListItemResponse(CARD_ID, "KC-0001", "AVAILABLE", null, null);
+    when(keycardService.getKeycards(any(), any(), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(List.of(item)));
+
+    mockMvc
+        .perform(get("/api/keycards"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].keycardNumber").value("KC-0001"))
+        .andExpect(jsonPath("$.content[0].status").value("AVAILABLE"));
+  }
+
+  @Test
+  void getKeycards_unauthenticated_returns401() throws Exception {
+    mockMvc.perform(get("/api/keycards")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser
+  void getKeycards_withStatusFilter_passes() throws Exception {
+    when(keycardService.getKeycards(any(), eq("in_use"), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(List.of()));
+
+    mockMvc
+        .perform(get("/api/keycards").param("status", "in_use"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isEmpty());
+  }
+
+  // ── GET /api/keycards/{cardId} ───────────────────────────────────────────────
+
+  @Test
+  @WithMockUser
+  void getKeycard_exists_returns200() throws Exception {
+    when(keycardService.getKeycard(CARD_ID)).thenReturn(sampleDetail());
+
+    mockMvc
+        .perform(get("/api/keycards/{id}", CARD_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.keycardNumber").value("KC-0001"))
+        .andExpect(jsonPath("$.active").value(true));
+  }
+
+  @Test
+  @WithMockUser
+  void getKeycard_notFound_returns404() throws Exception {
+    when(keycardService.getKeycard(CARD_ID))
+        .thenThrow(
+            new BusinessException(
+                "Keycard not found", ErrorCode.RESOURCE_NOT_FOUND, HttpStatus.NOT_FOUND));
+
+    mockMvc.perform(get("/api/keycards/{id}", CARD_ID)).andExpect(status().isNotFound());
+  }
+
+  // ── POST /api/keycards ───────────────────────────────────────────────────────
+
+  @Test
+  @WithMockUser
+  void createKeycard_validRequest_returns201() throws Exception {
+    CreateKeycardRequest request = new CreateKeycardRequest("KC-0099", null, true);
+    when(keycardService.createKeycard(any())).thenReturn(sampleDetail());
+
+    mockMvc
+        .perform(
+            post("/api/keycards")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.keycardNumber").value("KC-0001"));
+  }
+
+  @Test
+  @WithMockUser
+  void createKeycard_duplicateNumber_returns409() throws Exception {
+    CreateKeycardRequest request = new CreateKeycardRequest("KC-0001", null, true);
+    when(keycardService.createKeycard(any()))
+        .thenThrow(
+            new BusinessException(
+                "Keycard number already exists",
+                ErrorCode.RESOURCE_ALREADY_EXISTS,
+                HttpStatus.CONFLICT));
+
+    mockMvc
+        .perform(
+            post("/api/keycards")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  @WithMockUser
+  void createKeycard_blankNumber_returns400() throws Exception {
+    CreateKeycardRequest request = new CreateKeycardRequest("", null, true);
+
+    mockMvc
+        .perform(
+            post("/api/keycards")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isBadRequest());
+  }
+
+  // ── PUT /api/keycards/{cardId} ───────────────────────────────────────────────
+
+  @Test
+  @WithMockUser
+  void updateKeycard_validRequest_returns200() throws Exception {
+    UpdateKeycardRequest request = new UpdateKeycardRequest("KC-0001-NEW", true, null);
+    when(keycardService.updateKeycard(eq(CARD_ID), any())).thenReturn(sampleDetail());
+
+    mockMvc
+        .perform(
+            put("/api/keycards/{id}", CARD_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(CARD_ID.toString()));
+  }
+
+  @Test
+  @WithMockUser
+  void updateKeycard_notFound_returns404() throws Exception {
+    UpdateKeycardRequest request = new UpdateKeycardRequest(null, false, null);
+    when(keycardService.updateKeycard(eq(CARD_ID), any()))
+        .thenThrow(
+            new BusinessException(
+                "Keycard not found", ErrorCode.RESOURCE_NOT_FOUND, HttpStatus.NOT_FOUND));
+
+    mockMvc
+        .perform(
+            put("/api/keycards/{id}", CARD_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isNotFound());
+  }
+
+  // ── POST /api/keycards/{cardId}/assign ───────────────────────────────────────
+
+  @Test
+  @WithMockUser
+  void assignKeycard_valid_returns200() throws Exception {
+    AssignKeycardRequest request =
+        new AssignKeycardRequest(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+    KeycardDetailResponse withHolder =
+        new KeycardDetailResponse(
+            CARD_ID,
+            "KC-0001",
+            true,
+            null,
+            "Alice Smith",
+            UUID.randomUUID(),
+            LocalDateTime.now(),
+            null);
+    when(keycardService.assignKeycard(eq(CARD_ID), any())).thenReturn(withHolder);
+
+    mockMvc
+        .perform(
+            post("/api/keycards/{id}/assign", CARD_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.assignedUser").value("Alice Smith"));
+  }
+
+  @Test
+  @WithMockUser
+  void assignKeycard_alreadyAssigned_returns409() throws Exception {
+    AssignKeycardRequest request =
+        new AssignKeycardRequest(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+    when(keycardService.assignKeycard(eq(CARD_ID), any()))
+        .thenThrow(
+            new BusinessException(
+                "Keycard is already assigned",
+                ErrorCode.BUSINESS_RULE_VIOLATION,
+                HttpStatus.CONFLICT));
+
+    mockMvc
+        .perform(
+            post("/api/keycards/{id}/assign", CARD_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  @WithMockUser
+  void assignKeycard_missingBody_returns400() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/keycards/{id}/assign", CARD_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  // ── POST /api/keycards/{cardId}/return ───────────────────────────────────────
+
+  @Test
+  @WithMockUser
+  void returnKeycard_valid_returns200() throws Exception {
+    ReturnKeycardRequest request = new ReturnKeycardRequest(UUID.randomUUID());
+    LocalDateTime returnTime = LocalDateTime.now();
+    KeycardDetailResponse returned =
+        new KeycardDetailResponse(CARD_ID, "KC-0001", true, null, null, null, null, returnTime);
+    when(keycardService.returnKeycard(eq(CARD_ID), any())).thenReturn(returned);
+
+    mockMvc
+        .perform(
+            post("/api/keycards/{id}/return", CARD_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.lastReturnTime").isNotEmpty());
+  }
+
+  @Test
+  @WithMockUser
+  void returnKeycard_notAssigned_returns409() throws Exception {
+    ReturnKeycardRequest request = new ReturnKeycardRequest(UUID.randomUUID());
+    when(keycardService.returnKeycard(eq(CARD_ID), any()))
+        .thenThrow(
+            new BusinessException(
+                "Keycard is not currently assigned",
+                ErrorCode.BUSINESS_RULE_VIOLATION,
+                HttpStatus.CONFLICT));
+
+    mockMvc
+        .perform(
+            post("/api/keycards/{id}/return", CARD_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  @WithMockUser
+  void returnKeycard_missingBody_returns400() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/keycards/{id}/return", CARD_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+        .andExpect(status().isBadRequest());
+  }
+}

--- a/src/test/java/com/caffeine/acs_backend/controller/KeycardControllerTest.java
+++ b/src/test/java/com/caffeine/acs_backend/controller/KeycardControllerTest.java
@@ -16,8 +16,10 @@ import com.caffeine.acs_backend.dto.keycard.UpdateKeycardRequest;
 import com.caffeine.acs_backend.enums.errorcode.ErrorCode;
 import com.caffeine.acs_backend.exception.BusinessException;
 import com.caffeine.acs_backend.security.JwtAccessDeniedHandler;
+import com.caffeine.acs_backend.security.JwtAuthFilter;
 import com.caffeine.acs_backend.security.JwtAuthenticationEntryPoint;
 import com.caffeine.acs_backend.security.JwtService;
+import com.caffeine.acs_backend.security.SecurityConfig;
 import com.caffeine.acs_backend.service.KeycardService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
@@ -27,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -36,6 +39,8 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(KeycardController.class)
+@Import({SecurityConfig.class, JwtAuthFilter.class, JwtAccessDeniedHandler.class,
+    JwtAuthenticationEntryPoint.class})
 class KeycardControllerTest {
 
   @Autowired private MockMvc mockMvc;
@@ -43,11 +48,9 @@ class KeycardControllerTest {
 
   @MockBean private KeycardService keycardService;
 
-  // Real SecurityConfig runs; mock all its injected dependencies
+  // JwtAuthFilter dependencies — real filter runs, mock its collaborators
   @MockBean private JwtService jwtService;
   @MockBean private UserDetailsService userDetailsService;
-  @MockBean private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-  @MockBean private JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
   private static final UUID CARD_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
 
@@ -58,8 +61,8 @@ class KeycardControllerTest {
   // ── GET /api/keycards ────────────────────────────────────────────────────────
 
   @Test
-  @WithMockUser
-  void getKeycards_noFilters_returns200WithPage() throws Exception {
+  @WithMockUser(roles = "RECEPTIONIST")
+  void getKeycards_receptionist_returns200() throws Exception {
     KeycardListItemResponse item =
         new KeycardListItemResponse(CARD_ID, "KC-0001", "AVAILABLE", null, null);
     when(keycardService.getKeycards(any(), any(), any(Pageable.class)))
@@ -73,12 +76,27 @@ class KeycardControllerTest {
   }
 
   @Test
+  @WithMockUser(roles = "ADMIN")
+  void getKeycards_admin_returns200() throws Exception {
+    when(keycardService.getKeycards(any(), any(), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(List.of()));
+
+    mockMvc.perform(get("/api/keycards")).andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser(roles = "VISITOR")
+  void getKeycards_visitor_returns403() throws Exception {
+    mockMvc.perform(get("/api/keycards")).andExpect(status().isForbidden());
+  }
+
+  @Test
   void getKeycards_unauthenticated_returns401() throws Exception {
     mockMvc.perform(get("/api/keycards")).andExpect(status().isUnauthorized());
   }
 
   @Test
-  @WithMockUser
+  @WithMockUser(roles = "RECEPTIONIST")
   void getKeycards_withStatusFilter_passes() throws Exception {
     when(keycardService.getKeycards(any(), eq("in_use"), any(Pageable.class)))
         .thenReturn(new PageImpl<>(List.of()));
@@ -92,8 +110,8 @@ class KeycardControllerTest {
   // ── GET /api/keycards/{cardId} ───────────────────────────────────────────────
 
   @Test
-  @WithMockUser
-  void getKeycard_exists_returns200() throws Exception {
+  @WithMockUser(roles = "RECEPTIONIST")
+  void getKeycard_receptionist_returns200() throws Exception {
     when(keycardService.getKeycard(CARD_ID)).thenReturn(sampleDetail());
 
     mockMvc
@@ -104,7 +122,13 @@ class KeycardControllerTest {
   }
 
   @Test
-  @WithMockUser
+  @WithMockUser(roles = "VISITOR")
+  void getKeycard_visitor_returns403() throws Exception {
+    mockMvc.perform(get("/api/keycards/{id}", CARD_ID)).andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(roles = "RECEPTIONIST")
   void getKeycard_notFound_returns404() throws Exception {
     when(keycardService.getKeycard(CARD_ID))
         .thenThrow(
@@ -117,8 +141,8 @@ class KeycardControllerTest {
   // ── POST /api/keycards ───────────────────────────────────────────────────────
 
   @Test
-  @WithMockUser
-  void createKeycard_validRequest_returns201() throws Exception {
+  @WithMockUser(roles = "ADMIN")
+  void createKeycard_admin_returns201() throws Exception {
     CreateKeycardRequest request = new CreateKeycardRequest("KC-0099", null, true);
     when(keycardService.createKeycard(any())).thenReturn(sampleDetail());
 
@@ -133,7 +157,36 @@ class KeycardControllerTest {
   }
 
   @Test
-  @WithMockUser
+  @WithMockUser(roles = "SECURITY_CHIEF")
+  void createKeycard_securityChief_returns201() throws Exception {
+    CreateKeycardRequest request = new CreateKeycardRequest("KC-0099", null, true);
+    when(keycardService.createKeycard(any())).thenReturn(sampleDetail());
+
+    mockMvc
+        .perform(
+            post("/api/keycards")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated());
+  }
+
+  @Test
+  @WithMockUser(roles = "RECEPTIONIST")
+  void createKeycard_receptionist_returns403() throws Exception {
+    CreateKeycardRequest request = new CreateKeycardRequest("KC-0099", null, true);
+
+    mockMvc
+        .perform(
+            post("/api/keycards")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
   void createKeycard_duplicateNumber_returns409() throws Exception {
     CreateKeycardRequest request = new CreateKeycardRequest("KC-0001", null, true);
     when(keycardService.createKeycard(any()))
@@ -153,7 +206,7 @@ class KeycardControllerTest {
   }
 
   @Test
-  @WithMockUser
+  @WithMockUser(roles = "ADMIN")
   void createKeycard_blankNumber_returns400() throws Exception {
     CreateKeycardRequest request = new CreateKeycardRequest("", null, true);
 
@@ -169,8 +222,8 @@ class KeycardControllerTest {
   // ── PUT /api/keycards/{cardId} ───────────────────────────────────────────────
 
   @Test
-  @WithMockUser
-  void updateKeycard_validRequest_returns200() throws Exception {
+  @WithMockUser(roles = "ADMIN")
+  void updateKeycard_admin_returns200() throws Exception {
     UpdateKeycardRequest request = new UpdateKeycardRequest("KC-0001-NEW", true, null);
     when(keycardService.updateKeycard(eq(CARD_ID), any())).thenReturn(sampleDetail());
 
@@ -185,7 +238,21 @@ class KeycardControllerTest {
   }
 
   @Test
-  @WithMockUser
+  @WithMockUser(roles = "RECEPTIONIST")
+  void updateKeycard_receptionist_returns403() throws Exception {
+    UpdateKeycardRequest request = new UpdateKeycardRequest(null, false, null);
+
+    mockMvc
+        .perform(
+            put("/api/keycards/{id}", CARD_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
   void updateKeycard_notFound_returns404() throws Exception {
     UpdateKeycardRequest request = new UpdateKeycardRequest(null, false, null);
     when(keycardService.updateKeycard(eq(CARD_ID), any()))
@@ -205,8 +272,8 @@ class KeycardControllerTest {
   // ── POST /api/keycards/{cardId}/assign ───────────────────────────────────────
 
   @Test
-  @WithMockUser
-  void assignKeycard_valid_returns200() throws Exception {
+  @WithMockUser(roles = "RECEPTIONIST")
+  void assignKeycard_receptionist_returns200() throws Exception {
     AssignKeycardRequest request =
         new AssignKeycardRequest(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
     KeycardDetailResponse withHolder =
@@ -232,7 +299,22 @@ class KeycardControllerTest {
   }
 
   @Test
-  @WithMockUser
+  @WithMockUser(roles = "VISITOR")
+  void assignKeycard_visitor_returns403() throws Exception {
+    AssignKeycardRequest request =
+        new AssignKeycardRequest(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+
+    mockMvc
+        .perform(
+            post("/api/keycards/{id}/assign", CARD_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(roles = "RECEPTIONIST")
   void assignKeycard_alreadyAssigned_returns409() throws Exception {
     AssignKeycardRequest request =
         new AssignKeycardRequest(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
@@ -253,7 +335,7 @@ class KeycardControllerTest {
   }
 
   @Test
-  @WithMockUser
+  @WithMockUser(roles = "RECEPTIONIST")
   void assignKeycard_missingBody_returns400() throws Exception {
     mockMvc
         .perform(
@@ -267,8 +349,8 @@ class KeycardControllerTest {
   // ── POST /api/keycards/{cardId}/return ───────────────────────────────────────
 
   @Test
-  @WithMockUser
-  void returnKeycard_valid_returns200() throws Exception {
+  @WithMockUser(roles = "RECEPTIONIST")
+  void returnKeycard_receptionist_returns200() throws Exception {
     ReturnKeycardRequest request = new ReturnKeycardRequest(UUID.randomUUID());
     LocalDateTime returnTime = LocalDateTime.now();
     KeycardDetailResponse returned =
@@ -286,7 +368,21 @@ class KeycardControllerTest {
   }
 
   @Test
-  @WithMockUser
+  @WithMockUser(roles = "VISITOR")
+  void returnKeycard_visitor_returns403() throws Exception {
+    ReturnKeycardRequest request = new ReturnKeycardRequest(UUID.randomUUID());
+
+    mockMvc
+        .perform(
+            post("/api/keycards/{id}/return", CARD_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(roles = "RECEPTIONIST")
   void returnKeycard_notAssigned_returns409() throws Exception {
     ReturnKeycardRequest request = new ReturnKeycardRequest(UUID.randomUUID());
     when(keycardService.returnKeycard(eq(CARD_ID), any()))
@@ -306,7 +402,7 @@ class KeycardControllerTest {
   }
 
   @Test
-  @WithMockUser
+  @WithMockUser(roles = "RECEPTIONIST")
   void returnKeycard_missingBody_returns400() throws Exception {
     mockMvc
         .perform(

--- a/src/test/java/com/caffeine/acs_backend/service/KeycardServiceTest.java
+++ b/src/test/java/com/caffeine/acs_backend/service/KeycardServiceTest.java
@@ -22,7 +22,6 @@ import com.caffeine.acs_backend.repository.KeycardRepository;
 import com.caffeine.acs_backend.repository.PersonInRoleRepository;
 import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/caffeine/acs_backend/service/KeycardServiceTest.java
+++ b/src/test/java/com/caffeine/acs_backend/service/KeycardServiceTest.java
@@ -1,0 +1,325 @@
+package com.caffeine.acs_backend.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import com.caffeine.acs_backend.dto.keycard.AssignKeycardRequest;
+import com.caffeine.acs_backend.dto.keycard.CreateKeycardRequest;
+import com.caffeine.acs_backend.dto.keycard.KeycardDetailResponse;
+import com.caffeine.acs_backend.dto.keycard.ReturnKeycardRequest;
+import com.caffeine.acs_backend.entity.AccessPoint;
+import com.caffeine.acs_backend.entity.Keycard;
+import com.caffeine.acs_backend.entity.KeycardInPossession;
+import com.caffeine.acs_backend.entity.Person;
+import com.caffeine.acs_backend.entity.PersonInRole;
+import com.caffeine.acs_backend.exception.BusinessException;
+import com.caffeine.acs_backend.repository.AccessPointRepository;
+import com.caffeine.acs_backend.repository.KeycardInPossessionRepository;
+import com.caffeine.acs_backend.repository.KeycardRepository;
+import com.caffeine.acs_backend.repository.PersonInRoleRepository;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class KeycardServiceTest {
+
+  @Mock private KeycardRepository keycardRepository;
+  @Mock private KeycardInPossessionRepository keycardInPossessionRepository;
+  @Mock private PersonInRoleRepository personInRoleRepository;
+  @Mock private AccessPointRepository accessPointRepository;
+
+  @InjectMocks private KeycardService keycardService;
+
+  // ── Helpers ─────────────────────────────────────────────────────────────────
+
+  private Keycard activeKeycard() {
+    Keycard k = new Keycard();
+    k.setKeycardNumber("KC-0001");
+    k.setActive(true);
+    return k;
+  }
+
+  private PersonInRole personInRole(String givenName, String surname) {
+    Person person = new Person();
+    person.setGivenName(givenName);
+    person.setSurname(surname);
+    PersonInRole pir = new PersonInRole();
+    pir.setPerson(person);
+    return pir;
+  }
+
+  private AccessPoint accessPoint() {
+    return new AccessPoint();
+  }
+
+  // ── getKeycard ───────────────────────────────────────────────────────────────
+
+  @Test
+  void getKeycard_notFound_throwsBusinessException() {
+    UUID id = UUID.randomUUID();
+    when(keycardRepository.findById(id)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> keycardService.getKeycard(id))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(
+            ex -> assertThat(((BusinessException) ex).getStatus()).isEqualTo(HttpStatus.NOT_FOUND));
+  }
+
+  @Test
+  void getKeycard_found_returnsDetail() {
+    UUID id = UUID.randomUUID();
+    Keycard keycard = activeKeycard();
+    when(keycardRepository.findById(id)).thenReturn(Optional.of(keycard));
+    when(keycardInPossessionRepository.findActiveByKeycard(keycard)).thenReturn(Optional.empty());
+    when(keycardInPossessionRepository.findLatestByKeycard(eq(keycard), any()))
+        .thenReturn(Collections.emptyList());
+
+    KeycardDetailResponse response = keycardService.getKeycard(id);
+
+    assertThat(response.keycardNumber()).isEqualTo("KC-0001");
+    assertThat(response.assignedUser()).isNull();
+  }
+
+  // ── createKeycard ────────────────────────────────────────────────────────────
+
+  @Test
+  void createKeycard_duplicateNumber_throwsConflict() {
+    when(keycardRepository.existsByKeycardNumber("KC-0001")).thenReturn(true);
+
+    CreateKeycardRequest request = new CreateKeycardRequest("KC-0001", null, true);
+
+    assertThatThrownBy(() -> keycardService.createKeycard(request))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(
+            ex -> assertThat(((BusinessException) ex).getStatus()).isEqualTo(HttpStatus.CONFLICT));
+
+    verify(keycardRepository, never()).save(any());
+  }
+
+  @Test
+  void createKeycard_uniqueNumber_savesAndReturns() {
+    when(keycardRepository.existsByKeycardNumber("KC-0099")).thenReturn(false);
+    when(keycardRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    CreateKeycardRequest request = new CreateKeycardRequest("KC-0099", null, true);
+    KeycardDetailResponse response = keycardService.createKeycard(request);
+
+    assertThat(response.keycardNumber()).isEqualTo("KC-0099");
+    assertThat(response.active()).isTrue();
+    verify(keycardRepository).save(any(Keycard.class));
+  }
+
+  // ── assignKeycard ────────────────────────────────────────────────────────────
+
+  @Test
+  void assignKeycard_cardNotActive_throwsConflict() {
+    UUID id = UUID.randomUUID();
+    Keycard keycard = activeKeycard();
+    keycard.setActive(false);
+    when(keycardRepository.findById(id)).thenReturn(Optional.of(keycard));
+
+    AssignKeycardRequest request =
+        new AssignKeycardRequest(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+
+    assertThatThrownBy(() -> keycardService.assignKeycard(id, request))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(
+            ex -> assertThat(((BusinessException) ex).getStatus()).isEqualTo(HttpStatus.CONFLICT));
+  }
+
+  @Test
+  void assignKeycard_alreadyAssigned_throwsConflict() {
+    UUID id = UUID.randomUUID();
+    Keycard keycard = activeKeycard();
+    when(keycardRepository.findById(id)).thenReturn(Optional.of(keycard));
+    when(keycardInPossessionRepository.existsByKeycardAndReturnTimeIsNull(keycard))
+        .thenReturn(true);
+
+    AssignKeycardRequest request =
+        new AssignKeycardRequest(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+
+    assertThatThrownBy(() -> keycardService.assignKeycard(id, request))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(
+            ex -> assertThat(((BusinessException) ex).getStatus()).isEqualTo(HttpStatus.CONFLICT));
+  }
+
+  @Test
+  void assignKeycard_holderNotFound_throwsNotFound() {
+    UUID id = UUID.randomUUID();
+    UUID holderId = UUID.randomUUID();
+    Keycard keycard = activeKeycard();
+    when(keycardRepository.findById(id)).thenReturn(Optional.of(keycard));
+    when(keycardInPossessionRepository.existsByKeycardAndReturnTimeIsNull(keycard))
+        .thenReturn(false);
+    when(personInRoleRepository.findById(holderId)).thenReturn(Optional.empty());
+
+    AssignKeycardRequest request =
+        new AssignKeycardRequest(holderId, UUID.randomUUID(), UUID.randomUUID());
+
+    assertThatThrownBy(() -> keycardService.assignKeycard(id, request))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(
+            ex -> assertThat(((BusinessException) ex).getStatus()).isEqualTo(HttpStatus.NOT_FOUND));
+  }
+
+  @Test
+  void assignKeycard_assignorNotFound_throwsNotFound() {
+    UUID id = UUID.randomUUID();
+    UUID holderId = UUID.randomUUID();
+    UUID assignorId = UUID.randomUUID();
+    Keycard keycard = activeKeycard();
+    when(keycardRepository.findById(id)).thenReturn(Optional.of(keycard));
+    when(keycardInPossessionRepository.existsByKeycardAndReturnTimeIsNull(keycard))
+        .thenReturn(false);
+    when(personInRoleRepository.findById(holderId))
+        .thenReturn(Optional.of(personInRole("Alice", "Smith")));
+    when(personInRoleRepository.findById(assignorId)).thenReturn(Optional.empty());
+
+    AssignKeycardRequest request =
+        new AssignKeycardRequest(holderId, assignorId, UUID.randomUUID());
+
+    assertThatThrownBy(() -> keycardService.assignKeycard(id, request))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(
+            ex -> assertThat(((BusinessException) ex).getStatus()).isEqualTo(HttpStatus.NOT_FOUND));
+  }
+
+  @Test
+  void assignKeycard_accessPointNotFound_throwsNotFound() {
+    UUID id = UUID.randomUUID();
+    UUID holderId = UUID.randomUUID();
+    UUID assignorId = UUID.randomUUID();
+    UUID apId = UUID.randomUUID();
+    Keycard keycard = activeKeycard();
+    when(keycardRepository.findById(id)).thenReturn(Optional.of(keycard));
+    when(keycardInPossessionRepository.existsByKeycardAndReturnTimeIsNull(keycard))
+        .thenReturn(false);
+    when(personInRoleRepository.findById(holderId))
+        .thenReturn(Optional.of(personInRole("Alice", "Smith")));
+    when(personInRoleRepository.findById(assignorId))
+        .thenReturn(Optional.of(personInRole("Bob", "Jones")));
+    when(accessPointRepository.findById(apId)).thenReturn(Optional.empty());
+
+    AssignKeycardRequest request = new AssignKeycardRequest(holderId, assignorId, apId);
+
+    assertThatThrownBy(() -> keycardService.assignKeycard(id, request))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(
+            ex -> assertThat(((BusinessException) ex).getStatus()).isEqualTo(HttpStatus.NOT_FOUND));
+  }
+
+  @Test
+  void assignKeycard_success_savesAndReturns() {
+    UUID id = UUID.randomUUID();
+    UUID holderId = UUID.randomUUID();
+    UUID assignorId = UUID.randomUUID();
+    UUID apId = UUID.randomUUID();
+    Keycard keycard = activeKeycard();
+    PersonInRole holder = personInRole("Alice", "Smith");
+    PersonInRole assignor = personInRole("Bob", "Jones");
+    AccessPoint ap = accessPoint();
+
+    when(keycardRepository.findById(id)).thenReturn(Optional.of(keycard));
+    when(keycardInPossessionRepository.existsByKeycardAndReturnTimeIsNull(keycard))
+        .thenReturn(false);
+    when(personInRoleRepository.findById(holderId)).thenReturn(Optional.of(holder));
+    when(personInRoleRepository.findById(assignorId)).thenReturn(Optional.of(assignor));
+    when(accessPointRepository.findById(apId)).thenReturn(Optional.of(ap));
+    when(keycardInPossessionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    AssignKeycardRequest request = new AssignKeycardRequest(holderId, assignorId, apId);
+    KeycardDetailResponse response = keycardService.assignKeycard(id, request);
+
+    assertThat(response.assignedUser()).isEqualTo("Alice Smith");
+    assertThat(response.lastReturnTime()).isNull();
+    verify(keycardInPossessionRepository).save(any(KeycardInPossession.class));
+  }
+
+  // ── returnKeycard ────────────────────────────────────────────────────────────
+
+  @Test
+  void returnKeycard_notCurrentlyAssigned_throwsConflict() {
+    UUID id = UUID.randomUUID();
+    Keycard keycard = activeKeycard();
+    when(keycardRepository.findById(id)).thenReturn(Optional.of(keycard));
+    when(keycardInPossessionRepository.findActiveByKeycard(keycard)).thenReturn(Optional.empty());
+
+    ReturnKeycardRequest request = new ReturnKeycardRequest(UUID.randomUUID());
+
+    assertThatThrownBy(() -> keycardService.returnKeycard(id, request))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(
+            ex -> assertThat(((BusinessException) ex).getStatus()).isEqualTo(HttpStatus.CONFLICT));
+  }
+
+  @Test
+  void returnKeycard_returnAccessPointNotFound_throwsNotFound() {
+    UUID id = UUID.randomUUID();
+    UUID apId = UUID.randomUUID();
+    Keycard keycard = activeKeycard();
+    KeycardInPossession possession =
+        KeycardInPossession.builder()
+            .keycard(keycard)
+            .keycardHolder(personInRole("Alice", "Smith"))
+            .keycardAssignor(personInRole("Bob", "Jones"))
+            .assigningAccessPoint(accessPoint())
+            .assignedTime(LocalDateTime.now().minusHours(1))
+            .build();
+
+    when(keycardRepository.findById(id)).thenReturn(Optional.of(keycard));
+    when(keycardInPossessionRepository.findActiveByKeycard(keycard))
+        .thenReturn(Optional.of(possession));
+    when(accessPointRepository.findById(apId)).thenReturn(Optional.empty());
+
+    ReturnKeycardRequest request = new ReturnKeycardRequest(apId);
+
+    assertThatThrownBy(() -> keycardService.returnKeycard(id, request))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(
+            ex -> assertThat(((BusinessException) ex).getStatus()).isEqualTo(HttpStatus.NOT_FOUND));
+  }
+
+  @Test
+  void returnKeycard_success_setsReturnTimeAndAccessPoint() {
+    UUID id = UUID.randomUUID();
+    UUID apId = UUID.randomUUID();
+    Keycard keycard = activeKeycard();
+    AccessPoint returnAp = accessPoint();
+    KeycardInPossession possession =
+        KeycardInPossession.builder()
+            .keycard(keycard)
+            .keycardHolder(personInRole("Alice", "Smith"))
+            .keycardAssignor(personInRole("Bob", "Jones"))
+            .assigningAccessPoint(accessPoint())
+            .assignedTime(LocalDateTime.now().minusHours(1))
+            .build();
+
+    when(keycardRepository.findById(id)).thenReturn(Optional.of(keycard));
+    when(keycardInPossessionRepository.findActiveByKeycard(keycard))
+        .thenReturn(Optional.of(possession));
+    when(accessPointRepository.findById(apId)).thenReturn(Optional.of(returnAp));
+    when(keycardInPossessionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+    ReturnKeycardRequest request = new ReturnKeycardRequest(apId);
+    KeycardDetailResponse response = keycardService.returnKeycard(id, request);
+
+    assertThat(possession.getReturnAccessPoint()).isEqualTo(returnAp);
+    assertThat(possession.getReturnTime()).isNotNull();
+    assertThat(response.assignedUser()).isNull();
+    assertThat(response.lastReturnTime()).isNotNull();
+    verify(keycardInPossessionRepository).save(possession);
+  }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -13,3 +13,8 @@ spring.liquibase.enabled=false
 jwt.secret=dGVzdFNlY3JldEtleVdoaWNoSXNMb25nRW5vdWdoRm9ySG1hY1NoYTI1Ng==
 jwt.expiration=7200000
 jwt.refresh-expiration=172800000
+
+# Dummy mail config — prevents EmailService from failing to start in tests.
+# No emails are actually sent; the service swallows send errors gracefully.
+spring.mail.host=localhost
+spring.mail.port=25


### PR DESCRIPTION
These endpoints should allow the manipulation of records in the tables keycard and keycard_in_possession. I skipped the unnecessary or the columns that we don't have in our ERD. But what we have:

```
1. GET /keycards
Purpose: Return a paginated list of keycards with search and filtering options.
Query parameters:
search — card number, user name, or department
status — available, in_use, disabled, lost
page, size

Response fields:
keycard_number - from table keycard.keycard_number
status - from table keycard.is_active
assigned_user - from table person columns given_name and surname
last_return_time - from table keycard_in_possession column return_time
pagination metadata (for the keycard inventory management page in our app frontend)

2. GET /keycards/{cardId}
Purpose: Return detailed information for a single keycard.

3. POST /keycards
Purpose: Register a new RFID keycard.
Body: keycard_number, valid_until and initial_status intested into table keycard columns keycard_number, valid_until and is_active

4. PUT /keycards/{cardId}
Purpose: Update card metadata (status changes, deactivation, etc.).

5. POST /keycards/{cardId}/assign
Purpose: Mark a card as issued to a user.
Body: keycard_id, assigned_time (current time), keycard_holder_person_in_role_id, keycard_assignor_person_in_role_id, assigning_access_point_id to the table keycard_in_possession 

6. POST /keycards/{cardId}/return
Purpose: Mark a card as returned.
Body: keycard_id, return_access_point_id, return_time (current time) to the table keycard_in_possession
```

Example requests, not giving the output for all cases, because it would be too long.
```
* ── 0. Login ────────────────────────────────────────────────────────────────
TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"admin@dev.local","password":"password"}' \
  | jq -r '.accessToken')

echo "Token: $TOKEN"


* ── 1. Create new keycard ────────────────────────────────────────────────────
NEW_CARD=$(curl -s -X POST http://localhost:8080/api/keycards \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "keycardNumber": "KC-0099",
    "initialStatus": true
  }')

echo "Created keycard:"
echo $NEW_CARD | jq .

CARD_ID=$(echo $NEW_CARD | jq -r '.id')
echo "Card ID: $CARD_ID"


* ── 2. Update expiry to next year July ──────────────────────────────────────
curl -s -X PUT http://localhost:8080/api/keycards/$CARD_ID \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "validUntil": "2027-07-01T00:00:00"
  }' | jq .


* ── 3. Assign to Brian May ───────────────────────────────────────────────────
    * Brian May person_in_role:  ab000000-0000-0000-0000-000000000004
    * Assignor (Carol/receptionist): ab000000-0000-0000-0000-000000000003
    * Access point (Main Entrance):  a6000000-0000-0000-0000-000000000001

curl -s -X POST http://localhost:8080/api/keycards/$CARD_ID/assign \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "keycardHolderPersonInRoleId":   "ab000000-0000-0000-0000-000000000004",
    "keycardAssignorPersonInRoleId": "ab000000-0000-0000-0000-000000000003",
    "assigningAccessPointId":        "a6000000-0000-0000-0000-000000000001"
  }' | jq .


* ── 4. Search for Brian May in the list ─────────────────────────────────────
curl -s "http://localhost:8080/api/keycards?search=Brian" \
  -H "Authorization: Bearer $TOKEN" | jq .

{
  "content": [
    {
      "id": "fb0b1631-cacb-4efc-8b6f-ed6b5adde43c",
      "keycardNumber": "KC-0099",
      "status": "IN_USE",
      "assignedUser": "Brian May",
      "lastReturnTime": null
    }
  ],
  "pageable": {
    "pageNumber": 0,
    "pageSize": 20,
    "sort": {
      "sorted": false,
      "empty": true,
      "unsorted": true
    },
    "offset": 0,
    "paged": true,
    "unpaged": false
  },
  "last": true,
  "totalElements": 1,
  "totalPages": 1,
  "size": 20,
  "number": 0,
  "sort": {
    "sorted": false,
    "empty": true,
    "unsorted": true
  },
  "first": true,
  "numberOfElements": 1,
  "empty": false
}


* ── 5. Get full details of the new keycard ──────────────────────────────────
curl -s http://localhost:8080/api/keycards/$CARD_ID \
  -H "Authorization: Bearer $TOKEN" | jq .


* ── 6. Return the keycard via Side Gate ─────────────────────────────────────
    * Side Gate: a6000000-0000-0000-0000-000000000002
    * Note: return_time is set to server NOW(), not a custom time

curl -s -X POST http://localhost:8080/api/keycards/$CARD_ID/return \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "returnAccessPointId": "a6000000-0000-0000-0000-000000000002"
  }' | jq .
```


Also added some unit and integration tests
```
./mvnw test -Dtest="KeycardServiceTest,KeycardControllerTest" 2>&1 | grep -E "(Tests run|BUILD|FAIL|ERROR)"
[INFO] Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.915 s -- in com.caffeine.acs_backend.service.KeycardServiceTest
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.041 s -- in com.caffeine.acs_backend.controller.KeycardControllerTest
[INFO] Tests run: 37, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

# Keycard Test Suite

## KeycardServiceTest (13 tests)

Pure Mockito unit tests — no Spring context, no HTTP, no database.

### `getKeycard` (2 tests)

| Test | Verifies |
|------|----------|
| `getKeycard_notFound_throwsBusinessException` | Throws 404 when keycard UUID doesn't exist in repository |
| `getKeycard_found_returnsDetail` | Returns correct `keycardNumber`, null `assignedUser` when no active possession |

### `createKeycard` (2 tests)

| Test | Verifies |
|------|----------|
| `createKeycard_duplicateNumber_throwsConflict` | Throws 409 and never calls `save()` when number already exists |
| `createKeycard_uniqueNumber_savesAndReturns` | Saves a new `Keycard` entity and returns its detail |

### `assignKeycard` (6 tests)

| Test | Verifies |
|------|----------|
| `assignKeycard_cardNotActive_throwsConflict` | Throws 409 immediately when `isActive = false` |
| `assignKeycard_alreadyAssigned_throwsConflict` | Throws 409 when an active `KeycardInPossession` already exists |
| `assignKeycard_holderNotFound_throwsNotFound` | Throws 404 when holder `PersonInRole` UUID is unknown |
| `assignKeycard_assignorNotFound_throwsNotFound` | Throws 404 when assignor `PersonInRole` UUID is unknown |
| `assignKeycard_accessPointNotFound_throwsNotFound` | Throws 404 when access point UUID is unknown |
| `assignKeycard_success_savesAndReturns` | Saves `KeycardInPossession`, returns `assignedUser = "Alice Smith"` |

### `returnKeycard` (3 tests)

| Test | Verifies |
|------|----------|
| `returnKeycard_notCurrentlyAssigned_throwsConflict` | Throws 409 when no active possession exists |
| `returnKeycard_returnAccessPointNotFound_throwsNotFound` | Throws 404 when return access point UUID is unknown |
| `returnKeycard_success_setsReturnTimeAndAccessPoint` | Sets `returnTime` and `returnAccessPoint`, returns response with `lastReturnTime` set |

---

## KeycardControllerTest (24 tests)

`@WebMvcTest` slice with real `SecurityConfig` imported — tests HTTP routing, request validation, response JSON, and role-based access control.

### `GET /api/keycards` (5 tests)

| Test | Role | Verifies |
|------|------|----------|
| `getKeycards_receptionist_returns200` | `RECEPTIONIST` | 200 with `keycardNumber` and `status` in paginated response |
| `getKeycards_admin_returns200` | `ADMIN` | 200 with empty page |
| `getKeycards_visitor_returns403` | `VISITOR` | 403 Forbidden |
| `getKeycards_unauthenticated_returns401` | none | 401 Unauthorized |
| `getKeycards_withStatusFilter_passes` | `RECEPTIONIST` | `status` query param forwarded to service correctly |

### `GET /api/keycards/{cardId}` (3 tests)

| Test | Role | Verifies |
|------|------|----------|
| `getKeycard_receptionist_returns200` | `RECEPTIONIST` | 200 with `keycardNumber` and `active` in body |
| `getKeycard_visitor_returns403` | `VISITOR` | 403 Forbidden |
| `getKeycard_notFound_returns404` | `RECEPTIONIST` | 404 when service throws `NOT_FOUND` |

### `POST /api/keycards` (5 tests)

| Test | Role | Verifies |
|------|------|----------|
| `createKeycard_admin_returns201` | `ADMIN` | 201 with keycard body |
| `createKeycard_securityChief_returns201` | `SECURITY_CHIEF` | 201 — security chief can create |
| `createKeycard_receptionist_returns403` | `RECEPTIONIST` | 403 — receptionist cannot create |
| `createKeycard_duplicateNumber_returns409` | `ADMIN` | 409 when service throws conflict |
| `createKeycard_blankNumber_returns400` | `ADMIN` | 400 from Bean Validation on blank `keycardNumber` |

### `PUT /api/keycards/{cardId}` (3 tests)

| Test | Role | Verifies |
|------|------|----------|
| `updateKeycard_admin_returns200` | `ADMIN` | 200 with `id` in body |
| `updateKeycard_receptionist_returns403` | `RECEPTIONIST` | 403 — receptionist cannot update |
| `updateKeycard_notFound_returns404` | `ADMIN` | 404 when service throws `NOT_FOUND` |

### `POST /api/keycards/{cardId}/assign` (4 tests)

| Test | Role | Verifies |
|------|------|----------|
| `assignKeycard_receptionist_returns200` | `RECEPTIONIST` | 200 with `assignedUser = "Alice Smith"` |
| `assignKeycard_visitor_returns403` | `VISITOR` | 403 Forbidden |
| `assignKeycard_alreadyAssigned_returns409` | `RECEPTIONIST` | 409 when service throws conflict |
| `assignKeycard_missingBody_returns400` | `RECEPTIONIST` | 400 when all three required UUID fields are missing |

### `POST /api/keycards/{cardId}/return` (4 tests)

| Test | Role | Verifies |
|------|------|----------|
| `returnKeycard_receptionist_returns200` | `RECEPTIONIST` | 200 with `lastReturnTime` in body |
| `returnKeycard_visitor_returns403` | `VISITOR` | 403 Forbidden |
| `returnKeycard_notAssigned_returns409` | `RECEPTIONIST` | 409 when service throws conflict |
| `returnKeycard_missingBody_returns400` | `RECEPTIONIST` | 400 when `returnAccessPointId` is missing |





Couple of minor fixes and additions not directly related to Keycards:
* added running tests into the pipeline
* fixed the encrypted value of the password value "password" in the seed data