### PR TITLE
feature/27 visit related API endpoints

### DIFF
--- a/docs/api/keycard-endpoints.md
+++ b/docs/api/keycard-endpoints.md
@@ -1,0 +1,104 @@
+# Keycard Management — API Endpoints
+
+## Base path: `/api/keycards`
+
+All endpoints require a valid Bearer token (`Authorization: Bearer <token>`).
+
+---
+
+## Endpoints
+
+### `GET /api/keycards`
+**List keycards (paginated)**
+
+Query parameters: `search` (card number, holder name, department), `status` (`available` | `in_use` | `disabled`), `page`, `size`
+
+| Role | Access |
+|---|---|
+| ADMIN | allowed |
+| SECURITY_CHIEF | allowed |
+| RECEPTIONIST | allowed |
+| VISITOR | denied (403) |
+
+---
+
+### `GET /api/keycards/{cardId}`
+**Get keycard details**
+
+Returns full details for a single keycard including holder, assignor, and possession history.
+
+| Role | Access |
+|---|---|
+| ADMIN | allowed |
+| SECURITY_CHIEF | allowed |
+| RECEPTIONIST | allowed |
+| VISITOR | denied (403) |
+
+---
+
+### `POST /api/keycards`
+**Register new keycard**
+
+Body: `keycardNumber`, `active`, `validUntil` (optional). Fails with 409 if the card number already exists.
+
+| Role | Access |
+|---|---|
+| ADMIN | allowed |
+| SECURITY_CHIEF | allowed |
+| RECEPTIONIST | denied (403) |
+| VISITOR | denied (403) |
+
+---
+
+### `PUT /api/keycards/{cardId}`
+**Update keycard**
+
+Body: `keycardNumber` (optional), `active` (optional), `validUntil` (optional). Updates only the fields provided.
+
+| Role | Access |
+|---|---|
+| ADMIN | allowed |
+| SECURITY_CHIEF | allowed |
+| RECEPTIONIST | denied (403) |
+| VISITOR | denied (403) |
+
+---
+
+### `POST /api/keycards/{cardId}/assign`
+**Assign keycard to a person**
+
+Body: `personInRoleId`, `accessPointId`, `assignedTime` (optional). Fails with 409 if the card is already assigned, inactive, or expired.
+
+| Role | Access |
+|---|---|
+| ADMIN | allowed |
+| SECURITY_CHIEF | allowed |
+| RECEPTIONIST | allowed |
+| VISITOR | denied (403) |
+
+---
+
+### `POST /api/keycards/{cardId}/return`
+**Return keycard**
+
+Body: `accessPointId`, `returnTime` (optional). Marks the active possession record as returned. Fails with 409 if the card is not currently assigned.
+
+| Role | Access |
+|---|---|
+| ADMIN | allowed |
+| SECURITY_CHIEF | allowed |
+| RECEPTIONIST | allowed |
+| VISITOR | denied (403) |
+
+---
+
+## Role Summary
+
+| Endpoint | ADMIN | SECURITY_CHIEF | RECEPTIONIST | VISITOR |
+|---|:---:|:---:|:---:|:---:|
+| `GET /api/keycards` | yes | yes | yes | no |
+| `GET /api/keycards/{cardId}` | yes | yes | yes | no |
+| `POST /api/keycards` | yes | yes | **no** | no |
+| `PUT /api/keycards/{cardId}` | yes | yes | **no** | no |
+| `POST /api/keycards/{cardId}/assign` | yes | yes | yes | no |
+| `POST /api/keycards/{cardId}/return` | yes | yes | yes | no |

--- a/docs/api/visit-endpoints.md
+++ b/docs/api/visit-endpoints.md
@@ -1,0 +1,106 @@
+# Visit Activity Management — API Endpoints
+
+## Base path: `/api/visits`
+
+All endpoints require a valid Bearer token (`Authorization: Bearer <token>`).
+
+---
+
+## Endpoints
+
+### `GET /api/visits`
+**List visits (paginated)**
+
+Query parameters: `search`, `status` (`planned` | `in_building` | `departed` | `expired`), `dateFrom`, `dateTo`, `page`, `size`
+
+| Role | Access |
+|---|---|
+| ADMIN | allowed |
+| SECURITY_CHIEF | allowed |
+| RECEPTIONIST | allowed |
+| VISITOR | denied (403) |
+
+---
+
+### `GET /api/visits/{visitId}`
+**Get visit details**
+
+Returns visitor name, personal ID code, organization, department, host name, comment, and assigned card ID.
+
+| Role | Access |
+|---|---|
+| ADMIN | allowed |
+| SECURITY_CHIEF | allowed |
+| RECEPTIONIST | allowed |
+| VISITOR | denied (403) |
+
+---
+
+### `POST /api/visits`
+**Record a new visit**
+
+Body: `personId`, `accessPointId`, `keycardId` (optional), `hostPersonInRoleId` (optional), `comment`, `arrivalTime`. The authenticated user is used as the assignor.
+
+Returns full visitor details plus keycard assignment info.
+
+| Role | Access |
+|---|---|
+| ADMIN | allowed |
+| SECURITY_CHIEF | allowed |
+| RECEPTIONIST | allowed |
+| VISITOR | denied (403) |
+
+---
+
+### `PUT /api/visits/{visitId}/exit`
+**Record visitor departure**
+
+Body: `exitTime`. Fails with 409 if the visit already has an exit time.
+
+| Role | Access |
+|---|---|
+| ADMIN | allowed |
+| SECURITY_CHIEF | allowed |
+| RECEPTIONIST | allowed |
+| VISITOR | denied (403) |
+
+---
+
+### `PUT /api/visits/{visitId}/edit`
+**Edit visit details**
+
+Body: `hostId`, `assignorId`, `accessPointId`, `entryTime`, `comment`. Restricted to privileged roles only.
+
+| Role | Access |
+|---|---|
+| ADMIN | allowed |
+| SECURITY_CHIEF | allowed |
+| RECEPTIONIST | denied (403) |
+| VISITOR | denied (403) |
+
+---
+
+### `GET /api/visits/{visitId}/timeline`
+**Get visit audit timeline**
+
+Returns an ordered list of events (`ARRIVAL_REGISTERED`, `DEPARTURE_REGISTERED`) with timestamps and details.
+
+| Role | Access |
+|---|---|
+| ADMIN | allowed |
+| SECURITY_CHIEF | allowed |
+| RECEPTIONIST | allowed |
+| VISITOR | denied (403) |
+
+---
+
+## Role Summary
+
+| Endpoint | ADMIN | SECURITY_CHIEF | RECEPTIONIST | VISITOR |
+|---|:---:|:---:|:---:|:---:|
+| `GET /api/visits` | yes | yes | yes | no |
+| `GET /api/visits/{visitId}` | yes | yes | yes | no |
+| `POST /api/visits` | yes | yes | yes | no |
+| `PUT /api/visits/{visitId}/exit` | yes | yes | yes | no |
+| `PUT /api/visits/{visitId}/edit` | yes | yes | **no** | no |
+| `GET /api/visits/{visitId}/timeline` | yes | yes | yes | no |

--- a/src/main/java/com/caffeine/acs_backend/Application.java
+++ b/src/main/java/com/caffeine/acs_backend/Application.java
@@ -2,8 +2,11 @@ package com.caffeine.acs_backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode;
 
 @SpringBootApplication
+@EnableSpringDataWebSupport(pageSerializationMode = PageSerializationMode.VIA_DTO)
 public final class Application {
 
   private Application() {}

--- a/src/main/java/com/caffeine/acs_backend/controller/VisitController.java
+++ b/src/main/java/com/caffeine/acs_backend/controller/VisitController.java
@@ -31,7 +31,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/visits")
 @RequiredArgsConstructor
-@Tag(name = "Visits", description = "Visitor activity management")
+@Tag(name = "Visits", description = "Visit management")
 @SecurityRequirement(name = "bearerAuth")
 public class VisitController {
 

--- a/src/main/java/com/caffeine/acs_backend/controller/VisitController.java
+++ b/src/main/java/com/caffeine/acs_backend/controller/VisitController.java
@@ -2,6 +2,11 @@ package com.caffeine.acs_backend.controller;
 
 import com.caffeine.acs_backend.dto.visit.CreateVisitRequest;
 import com.caffeine.acs_backend.dto.visit.CreateVisitResponse;
+import com.caffeine.acs_backend.dto.visit.EditVisitRequest;
+import com.caffeine.acs_backend.dto.visit.ExitVisitRequest;
+import com.caffeine.acs_backend.dto.visit.VisitDetailResponse;
+import com.caffeine.acs_backend.dto.visit.VisitListItemResponse;
+import com.caffeine.acs_backend.dto.visit.VisitTimelineEntry;
 import com.caffeine.acs_backend.entity.User;
 import com.caffeine.acs_backend.service.VisitService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,33 +14,132 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/visits")
 @RequiredArgsConstructor
-@Tag(name = "Visits", description = "Visit registration")
+@Tag(name = "Visits", description = "Visitor activity management")
 @SecurityRequirement(name = "bearerAuth")
 public class VisitController {
+
+  private static final String ADMIN_OR_SECURITY_CHIEF = "hasAnyRole('ADMIN', 'SECURITY_CHIEF')";
+  private static final String ADMIN_SECURITY_CHIEF_OR_RECEPTIONIST =
+      "hasAnyRole('ADMIN', 'SECURITY_CHIEF', 'RECEPTIONIST')";
 
   private final VisitService visitService;
 
   @Operation(
+      summary = "List visits",
+      description =
+          "Returns a paginated list of visits."
+              + " Filter by status (planned, in_building, departed, expired) and date range."
+              + " Search by visitor name, document number, or host name."
+              + " Accessible by Admin, Security Chief, and Receptionist.")
+  @ApiResponse(responseCode = "200", description = "Visit list returned")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "403", description = "Forbidden")
+  @GetMapping
+  @PreAuthorize(ADMIN_SECURITY_CHIEF_OR_RECEPTIONIST)
+  public ResponseEntity<Page<VisitListItemResponse>> getVisits(
+      @RequestParam(required = false) String search,
+      @RequestParam(required = false) String status,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateFrom,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateTo,
+      @PageableDefault(size = 20) Pageable pageable) {
+    return ResponseEntity.ok(visitService.getVisits(search, status, dateFrom, dateTo, pageable));
+  }
+
+  @Operation(
+      summary = "Get visit details",
+      description =
+          "Returns full details for a single visit including visitor info, host, and assigned card."
+              + " Accessible by Admin, Security Chief, and Receptionist.")
+  @ApiResponse(responseCode = "200", description = "Visit returned")
+  @ApiResponse(responseCode = "404", description = "Visit not found")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "403", description = "Forbidden")
+  @GetMapping("/{visitId}")
+  @PreAuthorize(ADMIN_SECURITY_CHIEF_OR_RECEPTIONIST)
+  public ResponseEntity<VisitDetailResponse> getVisit(@PathVariable UUID visitId) {
+    return ResponseEntity.ok(visitService.getVisit(visitId));
+  }
+
+  @Operation(
+      summary = "Record visitor departure",
+      description =
+          "Sets the exit time on a visit, marking the visitor as departed."
+              + " Accessible by Admin, Security Chief, and Receptionist.")
+  @ApiResponse(responseCode = "200", description = "Exit recorded")
+  @ApiResponse(responseCode = "404", description = "Visit not found")
+  @ApiResponse(responseCode = "409", description = "Visit already has an exit time")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "403", description = "Forbidden")
+  @PutMapping("/{visitId}/exit")
+  @PreAuthorize(ADMIN_SECURITY_CHIEF_OR_RECEPTIONIST)
+  public ResponseEntity<VisitDetailResponse> exitVisit(
+      @PathVariable UUID visitId, @Valid @RequestBody ExitVisitRequest request) {
+    return ResponseEntity.ok(visitService.exitVisit(visitId, request));
+  }
+
+  @Operation(
+      summary = "Edit visit details",
+      description =
+          "Updates the entry time, host, and comment on an existing visit."
+              + " Accessible by Admin and Security Chief only.")
+  @ApiResponse(responseCode = "200", description = "Visit updated")
+  @ApiResponse(
+      responseCode = "404",
+      description = "Visit, assignor, access point, or host not found")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "403", description = "Forbidden")
+  @PutMapping("/{visitId}/edit")
+  @PreAuthorize(ADMIN_OR_SECURITY_CHIEF)
+  public ResponseEntity<VisitDetailResponse> editVisit(
+      @PathVariable UUID visitId, @Valid @RequestBody EditVisitRequest request) {
+    return ResponseEntity.ok(visitService.editVisit(visitId, request));
+  }
+
+  @Operation(
+      summary = "Get visit timeline",
+      description =
+          "Returns the ordered list of audit events for a visit (arrival, departure, etc.)."
+              + " Accessible by Admin, Security Chief, and Receptionist.")
+  @ApiResponse(responseCode = "200", description = "Timeline returned")
+  @ApiResponse(responseCode = "404", description = "Visit not found")
+  @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "403", description = "Forbidden")
+  @GetMapping("/{visitId}/timeline")
+  @PreAuthorize(ADMIN_SECURITY_CHIEF_OR_RECEPTIONIST)
+  public ResponseEntity<List<VisitTimelineEntry>> getTimeline(@PathVariable UUID visitId) {
+    return ResponseEntity.ok(visitService.getTimeline(visitId));
+  }
+
+  @Operation(
       summary = "Record a new visit",
       description =
-          "Records a visit and assigns a keycard to an visitor"
+          "Records a visit and optionally assigns a keycard to the visitor."
               + " The authenticated user acts as the assignor.")
-  @ApiResponse(responseCode = "201", description = "Visit recorded and keycard assigned for person")
+  @ApiResponse(responseCode = "201", description = "Visit recorded")
   @ApiResponse(responseCode = "400", description = "Validation error or keycard already assigned")
   @ApiResponse(responseCode = "401", description = "Unauthorized")
+  @ApiResponse(responseCode = "403", description = "Forbidden")
   @PostMapping
+  @PreAuthorize(ADMIN_SECURITY_CHIEF_OR_RECEPTIONIST)
   public ResponseEntity<CreateVisitResponse> createVisit(
       @Valid @RequestBody CreateVisitRequest request, @AuthenticationPrincipal User currentUser) {
     return ResponseEntity.status(HttpStatus.CREATED)

--- a/src/main/java/com/caffeine/acs_backend/dto/visit/CreateVisitResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/visit/CreateVisitResponse.java
@@ -10,7 +10,16 @@ public record CreateVisitResponse(
     @Schema(description = "Person ID of the visitor") UUID personId,
     @Schema(description = "PersonInRole ID representing the visitor role assignment")
         UUID personInRoleId,
+    @Schema(description = "Visitor's first name") String firstName,
+    @Schema(description = "Visitor's last name") String lastName,
+    @Schema(description = "Personal ID code / social security number") String personalIdCode,
+    @Schema(description = "Visitor's organization name, null if unaffiliated") String organization,
+    @Schema(description = "Visitor's department name, null if unaffiliated") String department,
+    @Schema(description = "Full name of the host, null if no host assigned") String hostName,
+    @Schema(description = "Purpose or notes about the visit") String comment,
+    @Schema(description = "Recorded arrival time") LocalDateTime arrivalTime,
+    @Schema(description = "ID of the keycard currently held by the visitor, null if none")
+        UUID cardId,
     @Schema(description = "KeycardInPossession record ID") UUID keycardInPossessionId,
     @Schema(description = "Keycard number that was assigned", example = "CARD-0042")
-        String keycardNumber,
-    @Schema(description = "Recorded arrival time") LocalDateTime arrivalTime) {}
+        String keycardNumber) {}

--- a/src/main/java/com/caffeine/acs_backend/dto/visit/EditVisitRequest.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/visit/EditVisitRequest.java
@@ -1,0 +1,16 @@
+package com.caffeine.acs_backend.dto.visit;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(description = "Request body for editing visit details")
+public record EditVisitRequest(
+    @Schema(description = "Host person ID (person.id) — null to clear the host") UUID hostId,
+    @Schema(description = "PersonInRole ID of the staff member making the edit") @NotNull
+        UUID assignorId,
+    @Schema(description = "Access point where the edit is being made") @NotNull UUID accessPointId,
+    @Schema(description = "Updated entry time") @NotNull LocalDateTime entryTime,
+    @Schema(description = "Updated visit purpose or notes") @Size(max = 1024) String comment) {}

--- a/src/main/java/com/caffeine/acs_backend/dto/visit/ExitVisitRequest.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/visit/ExitVisitRequest.java
@@ -1,0 +1,9 @@
+package com.caffeine.acs_backend.dto.visit;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+@Schema(description = "Request body for marking a visitor as departed")
+public record ExitVisitRequest(
+    @Schema(description = "Exit time") @NotNull LocalDateTime exitTime) {}

--- a/src/main/java/com/caffeine/acs_backend/dto/visit/VisitDetailResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/visit/VisitDetailResponse.java
@@ -1,0 +1,17 @@
+package com.caffeine.acs_backend.dto.visit;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+@Schema(description = "Full details for a single visit")
+public record VisitDetailResponse(
+    @Schema(description = "Visit ID") UUID visitId,
+    @Schema(description = "Visitor's first name", example = "John") String firstName,
+    @Schema(description = "Visitor's last name", example = "Smith") String lastName,
+    @Schema(description = "Personal ID code / social security number") String personalIdCode,
+    @Schema(description = "Visitor's organization name, null if unaffiliated") String organization,
+    @Schema(description = "Visitor's department name, null if unaffiliated") String department,
+    @Schema(description = "Full name of the host, null if no host assigned") String hostName,
+    @Schema(description = "Purpose or notes about the visit") String visitReason,
+    @Schema(description = "ID of the keycard currently held by the visitor, null if none")
+        UUID cardId) {}

--- a/src/main/java/com/caffeine/acs_backend/dto/visit/VisitListItemResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/visit/VisitListItemResponse.java
@@ -1,0 +1,32 @@
+package com.caffeine.acs_backend.dto.visit;
+
+import com.caffeine.acs_backend.repository.VisitListView;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(description = "Visit summary for paginated list view")
+public record VisitListItemResponse(
+    @Schema(description = "Visit ID") UUID id,
+    @Schema(description = "Full name of the visitor", example = "John Smith") String fullName,
+    @Schema(description = "Visitor's document number, null if none on record")
+        String documentNumber,
+    @Schema(description = "Full name of the host, null if no host assigned") String hostName,
+    @Schema(description = "Recorded entry time") LocalDateTime entryTime,
+    @Schema(description = "Recorded exit time, null if still inside") LocalDateTime exitTime,
+    @Schema(description = "Status: in_building, departed, or expired", example = "in_building")
+        String status,
+    @Schema(description = "person.id of the visitor") UUID visitorId) {
+
+  public static VisitListItemResponse from(VisitListView view) {
+    return new VisitListItemResponse(
+        view.getId(),
+        view.getFullName(),
+        view.getDocumentNumber(),
+        view.getHostName(),
+        view.getEntryTime(),
+        view.getExitTime(),
+        view.getStatus(),
+        view.getVisitorId());
+  }
+}

--- a/src/main/java/com/caffeine/acs_backend/dto/visit/VisitTimelineEntry.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/visit/VisitTimelineEntry.java
@@ -1,0 +1,10 @@
+package com.caffeine.acs_backend.dto.visit;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "A single audit entry in the visit timeline")
+public record VisitTimelineEntry(
+    @Schema(description = "When the event occurred") LocalDateTime timestamp,
+    @Schema(description = "Type of event", example = "ARRIVAL_REGISTERED") String eventType,
+    @Schema(description = "Additional details or comments") String details) {}

--- a/src/main/java/com/caffeine/acs_backend/repository/KeycardInPossessionRepository.java
+++ b/src/main/java/com/caffeine/acs_backend/repository/KeycardInPossessionRepository.java
@@ -22,6 +22,13 @@ public interface KeycardInPossessionRepository extends JpaRepository<KeycardInPo
 
   @Query(
       "SELECT kp FROM KeycardInPossession kp"
+          + " JOIN FETCH kp.keycard"
+          + " WHERE kp.keycardHolder = :holder AND kp.returnTime IS NULL")
+  Optional<KeycardInPossession> findActiveByHolder(
+      @Param("holder") com.caffeine.acs_backend.entity.PersonInRole holder);
+
+  @Query(
+      "SELECT kp FROM KeycardInPossession kp"
           + " JOIN FETCH kp.keycardHolder holder"
           + " JOIN FETCH holder.person"
           + " WHERE kp.keycard = :keycard"

--- a/src/main/java/com/caffeine/acs_backend/repository/VisitListView.java
+++ b/src/main/java/com/caffeine/acs_backend/repository/VisitListView.java
@@ -1,0 +1,29 @@
+package com.caffeine.acs_backend.repository;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/** Spring Data projection interface for the native visit list query. */
+public interface VisitListView {
+
+  UUID getId();
+
+  /** Full name of the visitor (given_name + surname). */
+  String getFullName();
+
+  /** Document number from the visitor's first document, null if none on record. */
+  String getDocumentNumber();
+
+  /** Full name of the host, null when no host assigned. */
+  String getHostName();
+
+  LocalDateTime getEntryTime();
+
+  LocalDateTime getExitTime();
+
+  /** Computed status: in_building, departed, or expired. */
+  String getStatus();
+
+  /** person.id of the visitor. */
+  UUID getVisitorId();
+}

--- a/src/main/java/com/caffeine/acs_backend/repository/VisitRepository.java
+++ b/src/main/java/com/caffeine/acs_backend/repository/VisitRepository.java
@@ -12,28 +12,115 @@ import org.springframework.data.repository.query.Param;
 public interface VisitRepository extends JpaRepository<Visit, UUID> {
 
   @Query(
+      nativeQuery = true,
+      value =
+          "SELECT"
+              + "  v.id                                                     AS \"id\","
+              + "  p.given_name || ' ' || p.surname                         AS \"fullName\","
+              + "  (SELECT d.document_number FROM document d"
+              + "   WHERE d.person_id = p.id LIMIT 1)                       AS \"documentNumber\","
+              + "  CASE WHEN hp.id IS NOT NULL"
+              + "    THEN hp.given_name || ' ' || hp.surname"
+              + "    ELSE NULL END                                           AS \"hostName\","
+              + "  v.arrival_time                                            AS \"entryTime\","
+              + "  v.exit_time                                               AS \"exitTime\","
+              + "  CASE"
+              + "    WHEN v.arrival_time > CURRENT_TIMESTAMP                THEN 'planned'"
+              + "    WHEN v.exit_time IS NOT NULL"
+              + "         AND v.exit_time <= CURRENT_TIMESTAMP               THEN 'departed'"
+              + "    WHEN v.arrival_time < CURRENT_DATE                     THEN 'expired'"
+              + "    ELSE                                                        'in_building'"
+              + "  END                                                       AS \"status\","
+              + "  p.id                                                      AS \"visitorId\""
+              + " FROM visit v"
+              + " JOIN person_in_role pir  ON pir.id = v.visitor_person_in_role_id"
+              + " JOIN person p            ON p.id = pir.person_id"
+              + " LEFT JOIN person_in_role hpir ON hpir.id = v.host_person_in_role_id"
+              + " LEFT JOIN person hp      ON hp.id = hpir.person_id"
+              + " WHERE"
+              + "   ( CAST(:search AS text) IS NULL"
+              + "     OR (p.given_name || ' ' || p.surname) ILIKE '%' || :search || '%'"
+              + "     OR EXISTS (SELECT 1 FROM document d"
+              + "                WHERE d.person_id = p.id"
+              + "                AND d.document_number ILIKE '%' || :search || '%')"
+              + "     OR (hp.given_name || ' ' || hp.surname) ILIKE '%' || :search || '%'"
+              + "   )"
+              + "   AND"
+              + "   ( CAST(:status AS text) IS NULL"
+              + "     OR (:status = 'planned'     AND v.arrival_time > CURRENT_TIMESTAMP)"
+              + "     OR (:status = 'in_building' AND v.exit_time IS NULL"
+              + "                                 AND v.arrival_time <= CURRENT_TIMESTAMP"
+              + "                                 AND v.arrival_time >= CURRENT_DATE)"
+              + "     OR (:status = 'departed'    AND v.exit_time IS NOT NULL"
+              + "                                 AND v.exit_time <= CURRENT_TIMESTAMP)"
+              + "     OR (:status = 'expired'     AND v.exit_time IS NULL"
+              + "                                 AND v.arrival_time < CURRENT_DATE)"
+              + "   )"
+              + "   AND (CAST(:dateFrom AS timestamp) IS NULL"
+              + "        OR v.arrival_time >= CAST(:dateFrom AS timestamp))"
+              + "   AND (CAST(:dateTo AS timestamp) IS NULL"
+              + "        OR v.arrival_time <= CAST(:dateTo AS timestamp))"
+              + " ORDER BY v.arrival_time DESC",
+      countQuery =
+          "SELECT COUNT(*)"
+              + " FROM visit v"
+              + " JOIN person_in_role pir  ON pir.id = v.visitor_person_in_role_id"
+              + " JOIN person p            ON p.id = pir.person_id"
+              + " LEFT JOIN person_in_role hpir ON hpir.id = v.host_person_in_role_id"
+              + " LEFT JOIN person hp      ON hp.id = hpir.person_id"
+              + " WHERE"
+              + "   ( CAST(:search AS text) IS NULL"
+              + "     OR (p.given_name || ' ' || p.surname) ILIKE '%' || :search || '%'"
+              + "     OR EXISTS (SELECT 1 FROM document d"
+              + "                WHERE d.person_id = p.id"
+              + "                AND d.document_number ILIKE '%' || :search || '%')"
+              + "     OR (hp.given_name || ' ' || hp.surname) ILIKE '%' || :search || '%'"
+              + "   )"
+              + "   AND"
+              + "   ( CAST(:status AS text) IS NULL"
+              + "     OR (:status = 'planned'     AND v.arrival_time > CURRENT_TIMESTAMP)"
+              + "     OR (:status = 'in_building' AND v.exit_time IS NULL"
+              + "                                 AND v.arrival_time <= CURRENT_TIMESTAMP"
+              + "                                 AND v.arrival_time >= CURRENT_DATE)"
+              + "     OR (:status = 'departed'    AND v.exit_time IS NOT NULL"
+              + "                                 AND v.exit_time <= CURRENT_TIMESTAMP)"
+              + "     OR (:status = 'expired'     AND v.exit_time IS NULL"
+              + "                                 AND v.arrival_time < CURRENT_DATE)"
+              + "   )"
+              + "   AND (CAST(:dateFrom AS timestamp) IS NULL"
+              + "        OR v.arrival_time >= CAST(:dateFrom AS timestamp))"
+              + "   AND (CAST(:dateTo AS timestamp) IS NULL"
+              + "        OR v.arrival_time <= CAST(:dateTo AS timestamp))")
+  Page<VisitListView> findAllFiltered(
+      @Param("search") String search,
+      @Param("status") String status,
+      @Param("dateFrom") LocalDateTime dateFrom,
+      @Param("dateTo") LocalDateTime dateTo,
+      Pageable pageable);
+
+  @Query(
       value =
           """
-      SELECT v.id, v.access_point_id, v.arrival_time,
-          v.assignor_person_in_role_id, v.comment, v.escort_person_in_role_id,
-          v.exit_time, v.group_in_visit_id, v.host_person_in_role_id,
-          v.notes, v.status, v.visitor_person_in_role_id, v.created_at
-      FROM visit v
-      WHERE (CAST(:status AS varchar) IS NULL OR v.status = CAST(:status AS varchar))
-      AND (CAST(:buildingId AS uuid) IS NULL OR v.access_point_id = CAST(:buildingId AS uuid))
-      AND (CAST(:from AS timestamp) IS NULL OR v.arrival_time >= CAST(:from AS timestamp))
-      AND (CAST(:to AS timestamp) IS NULL OR v.arrival_time < CAST(:to AS timestamp))
-      AND (CAST(:search AS varchar) IS NULL OR LOWER(v.notes) LIKE LOWER(CONCAT('%', :search, '%')))
-      """,
+          SELECT v.id, v.access_point_id, v.arrival_time,
+              v.assignor_person_in_role_id, v.comment, v.escort_person_in_role_id,
+              v.exit_time, v.group_in_visit_id, v.host_person_in_role_id,
+              v.notes, v.status, v.visitor_person_in_role_id, v.created_at
+          FROM visit v
+          WHERE (CAST(:status AS varchar) IS NULL OR v.status = CAST(:status AS varchar))
+          AND (CAST(:buildingId AS uuid) IS NULL OR v.access_point_id = CAST(:buildingId AS uuid))
+          AND (CAST(:from AS timestamp) IS NULL OR v.arrival_time >= CAST(:from AS timestamp))
+          AND (CAST(:to AS timestamp) IS NULL OR v.arrival_time < CAST(:to AS timestamp))
+          AND (CAST(:search AS varchar) IS NULL OR LOWER(v.notes) LIKE LOWER(CONCAT('%', :search, '%')))
+          """,
       countQuery =
           """
-      SELECT COUNT(*) FROM visit v
-      WHERE (CAST(:status AS varchar) IS NULL OR v.status = CAST(:status AS varchar))
-      AND (CAST(:buildingId AS uuid) IS NULL OR v.access_point_id = CAST(:buildingId AS uuid))
-      AND (CAST(:from AS timestamp) IS NULL OR v.arrival_time >= CAST(:from AS timestamp))
-      AND (CAST(:to AS timestamp) IS NULL OR v.arrival_time < CAST(:to AS timestamp))
-      AND (CAST(:search AS varchar) IS NULL OR LOWER(v.notes) LIKE LOWER(CONCAT('%', :search, '%')))
-      """,
+          SELECT COUNT(*) FROM visit v
+          WHERE (CAST(:status AS varchar) IS NULL OR v.status = CAST(:status AS varchar))
+          AND (CAST(:buildingId AS uuid) IS NULL OR v.access_point_id = CAST(:buildingId AS uuid))
+          AND (CAST(:from AS timestamp) IS NULL OR v.arrival_time >= CAST(:from AS timestamp))
+          AND (CAST(:to AS timestamp) IS NULL OR v.arrival_time < CAST(:to AS timestamp))
+          AND (CAST(:search AS varchar) IS NULL OR LOWER(v.notes) LIKE LOWER(CONCAT('%', :search, '%')))
+          """,
       nativeQuery = true)
   Page<Visit> findPreRegistrations(
       @Param("status") String status,

--- a/src/main/java/com/caffeine/acs_backend/service/VisitService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/VisitService.java
@@ -2,10 +2,23 @@ package com.caffeine.acs_backend.service;
 
 import com.caffeine.acs_backend.dto.visit.CreateVisitRequest;
 import com.caffeine.acs_backend.dto.visit.CreateVisitResponse;
+import com.caffeine.acs_backend.dto.visit.EditVisitRequest;
+import com.caffeine.acs_backend.dto.visit.ExitVisitRequest;
+import com.caffeine.acs_backend.dto.visit.VisitDetailResponse;
+import com.caffeine.acs_backend.dto.visit.VisitListItemResponse;
+import com.caffeine.acs_backend.dto.visit.VisitTimelineEntry;
 import com.caffeine.acs_backend.entity.*;
+import com.caffeine.acs_backend.enums.errorcode.ErrorCode;
+import com.caffeine.acs_backend.exception.BusinessException;
 import com.caffeine.acs_backend.repository.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,7 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class VisitService {
 
-  private static final String VISITOR_ROLE_NAME = "VISITOR";
+  private static final String VISITOR_ROLE_NAME = "Visitor";
 
   private final AccessPointRepository accessPointRepository;
   private final PersonInRoleRepository personInRoleRepository;
@@ -22,6 +35,135 @@ public class VisitService {
   private final RoleRepository roleRepository;
   private final PersonRepository personRepository;
   private final VisitRepository visitRepository;
+
+  // ── GET /visits ──────────────────────────────────────────────────────────────
+
+  @Transactional(readOnly = true)
+  public Page<VisitListItemResponse> getVisits(
+      String search,
+      String status,
+      LocalDateTime dateFrom,
+      LocalDateTime dateTo,
+      Pageable pageable) {
+    String searchParam = (search == null || search.isBlank()) ? null : search.trim();
+    String statusParam = (status == null || status.isBlank()) ? null : status.trim().toLowerCase();
+    return visitRepository
+        .findAllFiltered(searchParam, statusParam, dateFrom, dateTo, pageable)
+        .map(VisitListItemResponse::from);
+  }
+
+  // ── GET /visits/{visitId} ────────────────────────────────────────────────────
+
+  @Transactional(readOnly = true)
+  public VisitDetailResponse getVisit(UUID visitId) {
+    Visit visit = findVisitOrThrow(visitId);
+
+    Person person = visit.getVisitor().getPerson();
+
+    String hostName = null;
+    if (visit.getHost() != null) {
+      Person host = visit.getHost().getPerson();
+      hostName = host.getGivenName() + " " + host.getSurname();
+    }
+
+    UUID cardId =
+        keycardInPossessionRepository
+            .findActiveByHolder(visit.getVisitor())
+            .map(kip -> kip.getKeycard().getId())
+            .orElse(null);
+
+    return new VisitDetailResponse(
+        visit.getId(),
+        person.getGivenName(),
+        person.getSurname(),
+        person.getSocialSecurityNumber(),
+        person.getOrganization() != null ? person.getOrganization().getName() : null,
+        person.getDepartment() != null ? person.getDepartment().getName() : null,
+        hostName,
+        visit.getComment(),
+        cardId);
+  }
+
+  // ── PUT /visits/{visitId}/exit ────────────────────────────────────────────────
+
+  @Transactional
+  public VisitDetailResponse exitVisit(UUID visitId, ExitVisitRequest request) {
+    Visit visit = findVisitOrThrow(visitId);
+
+    if (visit.getExitTime() != null) {
+      throw new BusinessException(
+          "Visit already has an exit time recorded",
+          ErrorCode.BUSINESS_RULE_VIOLATION,
+          HttpStatus.CONFLICT);
+    }
+
+    visit.setExitTime(request.exitTime());
+    visitRepository.save(visit);
+
+    return buildDetailResponse(visit);
+  }
+
+  // ── PUT /visits/{visitId}/edit ────────────────────────────────────────────────
+
+  @Transactional
+  public VisitDetailResponse editVisit(UUID visitId, EditVisitRequest request) {
+    Visit visit = findVisitOrThrow(visitId);
+
+    // Resolve assignor and access point for audit trail
+    findPersonInRoleOrThrow(request.assignorId());
+    findAccessPointOrThrow(request.accessPointId());
+
+    // Update host — null clears it, non-null sets a new one
+    if (request.hostId() != null) {
+      Person hostPerson =
+          personRepository
+              .findById(request.hostId())
+              .orElseThrow(
+                  () ->
+                      new BusinessException(
+                          "Host person not found: " + request.hostId(),
+                          ErrorCode.RESOURCE_NOT_FOUND,
+                          HttpStatus.NOT_FOUND));
+      PersonInRole host =
+          personInRoleRepository
+              .findFirstByPersonAndIsActiveTrue(hostPerson)
+              .orElseThrow(
+                  () ->
+                      new BusinessException(
+                          "Host has no active role assignment: " + request.hostId(),
+                          ErrorCode.RESOURCE_NOT_FOUND,
+                          HttpStatus.NOT_FOUND));
+      visit.setHost(host);
+    } else {
+      visit.setHost(null);
+    }
+
+    visit.setArrivalTime(request.entryTime());
+    visit.setComment(request.comment());
+    visitRepository.save(visit);
+
+    return buildDetailResponse(visit);
+  }
+
+  // ── GET /visits/{visitId}/timeline ────────────────────────────────────────────
+
+  @Transactional(readOnly = true)
+  public List<VisitTimelineEntry> getTimeline(UUID visitId) {
+    Visit visit = findVisitOrThrow(visitId);
+
+    List<VisitTimelineEntry> entries = new ArrayList<>();
+
+    entries.add(
+        new VisitTimelineEntry(visit.getArrivalTime(), "ARRIVAL_REGISTERED", visit.getComment()));
+
+    if (visit.getExitTime() != null) {
+      entries.add(new VisitTimelineEntry(visit.getExitTime(), "DEPARTURE_REGISTERED", null));
+    }
+
+    return entries;
+  }
+
+  // ── Legacy createVisit (kept for backwards compatibility) ────────────────────
 
   @Transactional
   public CreateVisitResponse createVisit(CreateVisitRequest request, User assignorUser) {
@@ -57,7 +199,7 @@ public class VisitService {
       }
     }
 
-    PersonInRole assignor = resolveAssignor(assignorUser);
+    PersonInRole assignor = resolveAssignorFromUser(assignorUser);
 
     PersonInRole host = null;
     if (request.hostPersonInRoleId() != null) {
@@ -70,14 +212,7 @@ public class VisitService {
                           "Host not found: " + request.hostPersonInRoleId()));
     }
 
-    Role visitorRole =
-        roleRepository
-            .findByName(VISITOR_ROLE_NAME)
-            .orElseThrow(
-                () ->
-                    new IllegalStateException(
-                        "VISITOR role not configured in database. Please seed the roles table."));
-
+    Role visitorRole = findVisitorRole();
     PersonInRole visitorPersonInRole =
         personInRoleRepository
             .findByPersonAndRoleAndIsActiveTrue(person, visitorRole)
@@ -112,16 +247,107 @@ public class VisitService {
       keycardInPossessionRepository.save(possession);
     }
 
+    String hostName = null;
+    if (host != null) {
+      Person hostPerson = host.getPerson();
+      hostName = hostPerson.getGivenName() + " " + hostPerson.getSurname();
+    }
+
+    UUID cardId =
+        keycardInPossessionRepository
+            .findActiveByHolder(visitorPersonInRole)
+            .map(kip -> kip.getKeycard().getId())
+            .orElse(null);
+
     return new CreateVisitResponse(
         visit.getId(),
         person.getId(),
         visitorPersonInRole.getId(),
+        person.getGivenName(),
+        person.getSurname(),
+        person.getSocialSecurityNumber(),
+        person.getOrganization() != null ? person.getOrganization().getName() : null,
+        person.getDepartment() != null ? person.getDepartment().getName() : null,
+        hostName,
+        visit.getComment(),
+        now,
+        cardId,
         possession != null ? possession.getId() : null,
-        keycard != null ? keycard.getKeycardNumber() : null,
-        now);
+        keycard != null ? keycard.getKeycardNumber() : null);
   }
 
-  private PersonInRole resolveAssignor(User assignorUser) {
+  // ── Private helpers ──────────────────────────────────────────────────────────
+
+  private Visit findVisitOrThrow(UUID visitId) {
+    return visitRepository
+        .findById(visitId)
+        .orElseThrow(
+            () ->
+                new BusinessException(
+                    "Visit not found: " + visitId,
+                    ErrorCode.RESOURCE_NOT_FOUND,
+                    HttpStatus.NOT_FOUND));
+  }
+
+  private PersonInRole findPersonInRoleOrThrow(UUID personInRoleId) {
+    return personInRoleRepository
+        .findById(personInRoleId)
+        .orElseThrow(
+            () ->
+                new BusinessException(
+                    "PersonInRole not found: " + personInRoleId,
+                    ErrorCode.RESOURCE_NOT_FOUND,
+                    HttpStatus.NOT_FOUND));
+  }
+
+  private AccessPoint findAccessPointOrThrow(UUID accessPointId) {
+    return accessPointRepository
+        .findById(accessPointId)
+        .orElseThrow(
+            () ->
+                new BusinessException(
+                    "Access point not found: " + accessPointId,
+                    ErrorCode.RESOURCE_NOT_FOUND,
+                    HttpStatus.NOT_FOUND));
+  }
+
+  private Role findVisitorRole() {
+    return roleRepository
+        .findByName(VISITOR_ROLE_NAME)
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "VISITOR role not configured in database. Please seed the roles table."));
+  }
+
+  private VisitDetailResponse buildDetailResponse(Visit visit) {
+    Person person = visit.getVisitor().getPerson();
+
+    String hostName = null;
+    if (visit.getHost() != null) {
+      Person host = visit.getHost().getPerson();
+      hostName = host.getGivenName() + " " + host.getSurname();
+    }
+
+    UUID cardId =
+        keycardInPossessionRepository
+            .findActiveByHolder(visit.getVisitor())
+            .map(kip -> kip.getKeycard().getId())
+            .orElse(null);
+
+    return new VisitDetailResponse(
+        visit.getId(),
+        person.getGivenName(),
+        person.getSurname(),
+        person.getSocialSecurityNumber(),
+        person.getOrganization() != null ? person.getOrganization().getName() : null,
+        person.getDepartment() != null ? person.getDepartment().getName() : null,
+        hostName,
+        visit.getComment(),
+        cardId);
+  }
+
+  private PersonInRole resolveAssignorFromUser(User assignorUser) {
     if (assignorUser.getPerson() == null) {
       throw new IllegalStateException(
           "Your user account has no linked Person. Ask an administrator to link your profile.");

--- a/src/test/java/com/caffeine/acs_backend/controller/VisitControllerTest.java
+++ b/src/test/java/com/caffeine/acs_backend/controller/VisitControllerTest.java
@@ -1,0 +1,463 @@
+package com.caffeine.acs_backend.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.caffeine.acs_backend.dto.visit.CreateVisitRequest;
+import com.caffeine.acs_backend.dto.visit.CreateVisitResponse;
+import com.caffeine.acs_backend.dto.visit.EditVisitRequest;
+import com.caffeine.acs_backend.dto.visit.ExitVisitRequest;
+import com.caffeine.acs_backend.dto.visit.VisitDetailResponse;
+import com.caffeine.acs_backend.dto.visit.VisitListItemResponse;
+import com.caffeine.acs_backend.dto.visit.VisitTimelineEntry;
+import com.caffeine.acs_backend.entity.User;
+import com.caffeine.acs_backend.enums.UserRole;
+import com.caffeine.acs_backend.enums.errorcode.ErrorCode;
+import com.caffeine.acs_backend.exception.BusinessException;
+import com.caffeine.acs_backend.security.JwtAccessDeniedHandler;
+import com.caffeine.acs_backend.security.JwtAuthFilter;
+import com.caffeine.acs_backend.security.JwtAuthenticationEntryPoint;
+import com.caffeine.acs_backend.security.JwtService;
+import com.caffeine.acs_backend.security.SecurityConfig;
+import com.caffeine.acs_backend.service.VisitService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(VisitController.class)
+@Import({
+  SecurityConfig.class,
+  JwtAuthFilter.class,
+  JwtAccessDeniedHandler.class,
+  JwtAuthenticationEntryPoint.class
+})
+class VisitControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
+
+  @MockBean private VisitService visitService;
+
+  // JwtAuthFilter dependencies — real filter runs, mock its collaborators
+  @MockBean private JwtService jwtService;
+  @MockBean private UserDetailsService userDetailsService;
+
+  private static final UUID VISIT_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+  private static final UUID PERSON_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+
+  // ── Helpers ──────────────────────────────────────────────────────────────────
+
+  /** Creates a real entity User for @AuthenticationPrincipal endpoints. */
+  private User entityUser(UserRole role) {
+    return User.builder()
+        .email(role.name().toLowerCase() + "@test.local")
+        .password("pw")
+        .role(role)
+        .build();
+  }
+
+  private VisitDetailResponse sampleDetail() {
+    return new VisitDetailResponse(
+        VISIT_ID, "John", "Smith", null, null, null, null, "Test visit", null);
+  }
+
+  private CreateVisitResponse sampleCreateResponse() {
+    return new CreateVisitResponse(
+        VISIT_ID,
+        PERSON_ID,
+        UUID.randomUUID(),
+        "John",
+        "Smith",
+        null,
+        null,
+        null,
+        null,
+        "Test visit",
+        LocalDateTime.now(),
+        null,
+        null,
+        null);
+  }
+
+  // ── GET /api/visits ──────────────────────────────────────────────────────────
+
+  @Test
+  @WithMockUser(roles = "RECEPTIONIST")
+  void getVisits_receptionist_returns200() throws Exception {
+    VisitListItemResponse item =
+        new VisitListItemResponse(
+            VISIT_ID,
+            "John Smith",
+            null,
+            null,
+            LocalDateTime.now(),
+            null,
+            "in_building",
+            PERSON_ID);
+    when(visitService.getVisits(any(), any(), any(), any(), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(List.of(item)));
+
+    mockMvc
+        .perform(get("/api/visits"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].fullName").value("John Smith"))
+        .andExpect(jsonPath("$.content[0].status").value("in_building"));
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void getVisits_admin_returns200() throws Exception {
+    when(visitService.getVisits(any(), any(), any(), any(), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(List.of()));
+
+    mockMvc.perform(get("/api/visits")).andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser(roles = "VISITOR")
+  void getVisits_visitor_returns403() throws Exception {
+    mockMvc.perform(get("/api/visits")).andExpect(status().isForbidden());
+  }
+
+  @Test
+  void getVisits_unauthenticated_returns401() throws Exception {
+    mockMvc.perform(get("/api/visits")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser(roles = "RECEPTIONIST")
+  void getVisits_withStatusFilter_passesParam() throws Exception {
+    when(visitService.getVisits(any(), eq("in_building"), any(), any(), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(List.of()));
+
+    mockMvc
+        .perform(get("/api/visits").param("status", "in_building"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content").isEmpty());
+  }
+
+  // ── GET /api/visits/{visitId} ────────────────────────────────────────────────
+
+  @Test
+  @WithMockUser(roles = "RECEPTIONIST")
+  void getVisit_receptionist_returns200() throws Exception {
+    when(visitService.getVisit(VISIT_ID)).thenReturn(sampleDetail());
+
+    mockMvc
+        .perform(get("/api/visits/{id}", VISIT_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.firstName").value("John"))
+        .andExpect(jsonPath("$.lastName").value("Smith"))
+        .andExpect(jsonPath("$.visitId").value(VISIT_ID.toString()));
+  }
+
+  @Test
+  @WithMockUser(roles = "VISITOR")
+  void getVisit_visitor_returns403() throws Exception {
+    mockMvc.perform(get("/api/visits/{id}", VISIT_ID)).andExpect(status().isForbidden());
+  }
+
+  @Test
+  void getVisit_unauthenticated_returns401() throws Exception {
+    mockMvc.perform(get("/api/visits/{id}", VISIT_ID)).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser(roles = "RECEPTIONIST")
+  void getVisit_notFound_returns404() throws Exception {
+    when(visitService.getVisit(VISIT_ID))
+        .thenThrow(
+            new BusinessException(
+                "Visit not found", ErrorCode.RESOURCE_NOT_FOUND, HttpStatus.NOT_FOUND));
+
+    mockMvc.perform(get("/api/visits/{id}", VISIT_ID)).andExpect(status().isNotFound());
+  }
+
+  // ── POST /api/visits ─────────────────────────────────────────────────────────
+  // Uses @AuthenticationPrincipal User — must inject real entity User via .with(user(...))
+
+  @Test
+  void createVisit_receptionist_returns201() throws Exception {
+    CreateVisitRequest request =
+        new CreateVisitRequest(
+            PERSON_ID, UUID.randomUUID(), null, null, "Test", LocalDateTime.now());
+    when(visitService.createVisit(any(), any())).thenReturn(sampleCreateResponse());
+
+    mockMvc
+        .perform(
+            post("/api/visits")
+                .with(user(entityUser(UserRole.RECEPTIONIST)))
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.visitId").value(VISIT_ID.toString()))
+        .andExpect(jsonPath("$.firstName").value("John"));
+  }
+
+  @Test
+  void createVisit_securityChief_returns201() throws Exception {
+    CreateVisitRequest request =
+        new CreateVisitRequest(PERSON_ID, UUID.randomUUID(), null, null, null, null);
+    when(visitService.createVisit(any(), any())).thenReturn(sampleCreateResponse());
+
+    mockMvc
+        .perform(
+            post("/api/visits")
+                .with(user(entityUser(UserRole.SECURITY_CHIEF)))
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isCreated());
+  }
+
+  @Test
+  void createVisit_visitor_returns403() throws Exception {
+    CreateVisitRequest request =
+        new CreateVisitRequest(PERSON_ID, UUID.randomUUID(), null, null, null, null);
+
+    mockMvc
+        .perform(
+            post("/api/visits")
+                .with(user(entityUser(UserRole.VISITOR)))
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void createVisit_missingRequiredFields_returns400() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/visits")
+                .with(user(entityUser(UserRole.RECEPTIONIST)))
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  // ── PUT /api/visits/{visitId}/exit ────────────────────────────────────────────
+
+  @Test
+  @WithMockUser(roles = "RECEPTIONIST")
+  void exitVisit_receptionist_returns200() throws Exception {
+    ExitVisitRequest request = new ExitVisitRequest(LocalDateTime.now());
+    when(visitService.exitVisit(eq(VISIT_ID), any())).thenReturn(sampleDetail());
+
+    mockMvc
+        .perform(
+            put("/api/visits/{id}/exit", VISIT_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.visitId").value(VISIT_ID.toString()));
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void exitVisit_admin_returns200() throws Exception {
+    ExitVisitRequest request = new ExitVisitRequest(LocalDateTime.now());
+    when(visitService.exitVisit(eq(VISIT_ID), any())).thenReturn(sampleDetail());
+
+    mockMvc
+        .perform(
+            put("/api/visits/{id}/exit", VISIT_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser(roles = "VISITOR")
+  void exitVisit_visitor_returns403() throws Exception {
+    ExitVisitRequest request = new ExitVisitRequest(LocalDateTime.now());
+
+    mockMvc
+        .perform(
+            put("/api/visits/{id}/exit", VISIT_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(roles = "RECEPTIONIST")
+  void exitVisit_alreadyExited_returns409() throws Exception {
+    ExitVisitRequest request = new ExitVisitRequest(LocalDateTime.now());
+    when(visitService.exitVisit(eq(VISIT_ID), any()))
+        .thenThrow(
+            new BusinessException(
+                "Visit already has an exit time",
+                ErrorCode.BUSINESS_RULE_VIOLATION,
+                HttpStatus.CONFLICT));
+
+    mockMvc
+        .perform(
+            put("/api/visits/{id}/exit", VISIT_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  @WithMockUser(roles = "RECEPTIONIST")
+  void exitVisit_missingExitTime_returns400() throws Exception {
+    mockMvc
+        .perform(
+            put("/api/visits/{id}/exit", VISIT_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  // ── PUT /api/visits/{visitId}/edit ────────────────────────────────────────────
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void editVisit_admin_returns200() throws Exception {
+    EditVisitRequest request =
+        new EditVisitRequest(
+            null, UUID.randomUUID(), UUID.randomUUID(), LocalDateTime.now(), "Updated");
+    when(visitService.editVisit(eq(VISIT_ID), any())).thenReturn(sampleDetail());
+
+    mockMvc
+        .perform(
+            put("/api/visits/{id}/edit", VISIT_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.visitId").value(VISIT_ID.toString()));
+  }
+
+  @Test
+  @WithMockUser(roles = "SECURITY_CHIEF")
+  void editVisit_securityChief_returns200() throws Exception {
+    EditVisitRequest request =
+        new EditVisitRequest(null, UUID.randomUUID(), UUID.randomUUID(), LocalDateTime.now(), null);
+    when(visitService.editVisit(eq(VISIT_ID), any())).thenReturn(sampleDetail());
+
+    mockMvc
+        .perform(
+            put("/api/visits/{id}/edit", VISIT_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser(roles = "RECEPTIONIST")
+  void editVisit_receptionist_returns403() throws Exception {
+    EditVisitRequest request =
+        new EditVisitRequest(null, UUID.randomUUID(), UUID.randomUUID(), LocalDateTime.now(), null);
+
+    mockMvc
+        .perform(
+            put("/api/visits/{id}/edit", VISIT_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void editVisit_notFound_returns404() throws Exception {
+    EditVisitRequest request =
+        new EditVisitRequest(null, UUID.randomUUID(), UUID.randomUUID(), LocalDateTime.now(), null);
+    when(visitService.editVisit(eq(VISIT_ID), any()))
+        .thenThrow(
+            new BusinessException(
+                "Visit not found", ErrorCode.RESOURCE_NOT_FOUND, HttpStatus.NOT_FOUND));
+
+    mockMvc
+        .perform(
+            put("/api/visits/{id}/edit", VISIT_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void editVisit_missingRequiredFields_returns400() throws Exception {
+    mockMvc
+        .perform(
+            put("/api/visits/{id}/edit", VISIT_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  // ── GET /api/visits/{visitId}/timeline ────────────────────────────────────────
+
+  @Test
+  @WithMockUser(roles = "RECEPTIONIST")
+  void getTimeline_receptionist_returns200() throws Exception {
+    List<VisitTimelineEntry> entries =
+        List.of(
+            new VisitTimelineEntry(
+                LocalDateTime.now().minusHours(2), "ARRIVAL_REGISTERED", "Test visit"),
+            new VisitTimelineEntry(
+                LocalDateTime.now().minusMinutes(30), "DEPARTURE_REGISTERED", null));
+    when(visitService.getTimeline(VISIT_ID)).thenReturn(entries);
+
+    mockMvc
+        .perform(get("/api/visits/{id}/timeline", VISIT_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].eventType").value("ARRIVAL_REGISTERED"))
+        .andExpect(jsonPath("$[1].eventType").value("DEPARTURE_REGISTERED"));
+  }
+
+  @Test
+  @WithMockUser(roles = "VISITOR")
+  void getTimeline_visitor_returns403() throws Exception {
+    mockMvc.perform(get("/api/visits/{id}/timeline", VISIT_ID)).andExpect(status().isForbidden());
+  }
+
+  @Test
+  void getTimeline_unauthenticated_returns401() throws Exception {
+    mockMvc
+        .perform(get("/api/visits/{id}/timeline", VISIT_ID))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser(roles = "RECEPTIONIST")
+  void getTimeline_notFound_returns404() throws Exception {
+    when(visitService.getTimeline(VISIT_ID))
+        .thenThrow(
+            new BusinessException(
+                "Visit not found", ErrorCode.RESOURCE_NOT_FOUND, HttpStatus.NOT_FOUND));
+
+    mockMvc.perform(get("/api/visits/{id}/timeline", VISIT_ID)).andExpect(status().isNotFound());
+  }
+}

--- a/src/test/java/com/caffeine/acs_backend/service/VisitServiceTest.java
+++ b/src/test/java/com/caffeine/acs_backend/service/VisitServiceTest.java
@@ -1,0 +1,369 @@
+package com.caffeine.acs_backend.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.caffeine.acs_backend.dto.visit.EditVisitRequest;
+import com.caffeine.acs_backend.dto.visit.ExitVisitRequest;
+import com.caffeine.acs_backend.dto.visit.VisitDetailResponse;
+import com.caffeine.acs_backend.dto.visit.VisitTimelineEntry;
+import com.caffeine.acs_backend.entity.*;
+import com.caffeine.acs_backend.exception.BusinessException;
+import com.caffeine.acs_backend.repository.*;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class VisitServiceTest {
+
+  @Mock private AccessPointRepository accessPointRepository;
+  @Mock private PersonInRoleRepository personInRoleRepository;
+  @Mock private KeycardRepository keycardRepository;
+  @Mock private KeycardInPossessionRepository keycardInPossessionRepository;
+  @Mock private RoleRepository roleRepository;
+  @Mock private PersonRepository personRepository;
+  @Mock private VisitRepository visitRepository;
+
+  @InjectMocks private VisitService visitService;
+
+  // ── Helpers ──────────────────────────────────────────────────────────────────
+
+  private Person person(String givenName, String surname) {
+    Person p = new Person();
+    p.setGivenName(givenName);
+    p.setSurname(surname);
+    return p;
+  }
+
+  private PersonInRole personInRole(String givenName, String surname) {
+    PersonInRole pir = new PersonInRole();
+    pir.setPerson(person(givenName, surname));
+    return pir;
+  }
+
+  private Visit visitWithVisitor(PersonInRole visitor) {
+    return Visit.builder()
+        .arrivalTime(LocalDateTime.now().minusHours(1))
+        .accessPoint(new AccessPoint())
+        .visitor(visitor)
+        .assignor(personInRole("Assignor", "User"))
+        .build();
+  }
+
+  // ── getVisit ─────────────────────────────────────────────────────────────────
+
+  @Test
+  void getVisit_notFound_throwsBusinessException() {
+    UUID id = UUID.randomUUID();
+    when(visitRepository.findById(id)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> visitService.getVisit(id))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(
+            ex -> assertThat(((BusinessException) ex).getStatus()).isEqualTo(HttpStatus.NOT_FOUND));
+  }
+
+  @Test
+  void getVisit_found_noHost_noCard_returnsDetail() {
+    UUID id = UUID.randomUUID();
+    PersonInRole visitor = personInRole("John", "Smith");
+    Visit visit = visitWithVisitor(visitor);
+    visit.setId(id);
+    visit.setComment("Test visit");
+
+    when(visitRepository.findById(id)).thenReturn(Optional.of(visit));
+    when(keycardInPossessionRepository.findActiveByHolder(visitor)).thenReturn(Optional.empty());
+
+    VisitDetailResponse response = visitService.getVisit(id);
+
+    assertThat(response.firstName()).isEqualTo("John");
+    assertThat(response.lastName()).isEqualTo("Smith");
+    assertThat(response.hostName()).isNull();
+    assertThat(response.cardId()).isNull();
+    assertThat(response.visitReason()).isEqualTo("Test visit");
+  }
+
+  @Test
+  void getVisit_withHost_includesHostName() {
+    UUID id = UUID.randomUUID();
+    PersonInRole visitor = personInRole("Jane", "Doe");
+    PersonInRole host = personInRole("Host", "Person");
+    Visit visit = visitWithVisitor(visitor);
+    visit.setId(id);
+    visit.setHost(host);
+
+    when(visitRepository.findById(id)).thenReturn(Optional.of(visit));
+    when(keycardInPossessionRepository.findActiveByHolder(visitor)).thenReturn(Optional.empty());
+
+    VisitDetailResponse response = visitService.getVisit(id);
+
+    assertThat(response.hostName()).isEqualTo("Host Person");
+  }
+
+  @Test
+  void getVisit_withActiveCard_returnsCardId() {
+    UUID id = UUID.randomUUID();
+    UUID cardId = UUID.randomUUID();
+    PersonInRole visitor = personInRole("John", "Smith");
+    Visit visit = visitWithVisitor(visitor);
+    visit.setId(id);
+
+    Keycard keycard = new Keycard();
+    keycard.setId(cardId);
+    KeycardInPossession possession =
+        KeycardInPossession.builder().keycard(keycard).keycardHolder(visitor).build();
+
+    when(visitRepository.findById(id)).thenReturn(Optional.of(visit));
+    when(keycardInPossessionRepository.findActiveByHolder(visitor))
+        .thenReturn(Optional.of(possession));
+
+    VisitDetailResponse response = visitService.getVisit(id);
+
+    assertThat(response.cardId()).isEqualTo(cardId);
+  }
+
+  // ── exitVisit ────────────────────────────────────────────────────────────────
+
+  @Test
+  void exitVisit_notFound_throwsBusinessException() {
+    UUID id = UUID.randomUUID();
+    when(visitRepository.findById(id)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> visitService.exitVisit(id, new ExitVisitRequest(LocalDateTime.now())))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(
+            ex -> assertThat(((BusinessException) ex).getStatus()).isEqualTo(HttpStatus.NOT_FOUND));
+  }
+
+  @Test
+  void exitVisit_alreadyExited_throwsConflict() {
+    UUID id = UUID.randomUUID();
+    PersonInRole visitor = personInRole("John", "Smith");
+    Visit visit = visitWithVisitor(visitor);
+    visit.setExitTime(LocalDateTime.now().minusMinutes(30));
+
+    when(visitRepository.findById(id)).thenReturn(Optional.of(visit));
+
+    assertThatThrownBy(() -> visitService.exitVisit(id, new ExitVisitRequest(LocalDateTime.now())))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(
+            ex -> assertThat(((BusinessException) ex).getStatus()).isEqualTo(HttpStatus.CONFLICT));
+
+    verify(visitRepository, never()).save(any());
+  }
+
+  @Test
+  void exitVisit_success_setsExitTimeAndSaves() {
+    UUID id = UUID.randomUUID();
+    PersonInRole visitor = personInRole("John", "Smith");
+    Visit visit = visitWithVisitor(visitor);
+    visit.setId(id);
+    LocalDateTime exitTime = LocalDateTime.now();
+
+    when(visitRepository.findById(id)).thenReturn(Optional.of(visit));
+    when(visitRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(keycardInPossessionRepository.findActiveByHolder(visitor)).thenReturn(Optional.empty());
+
+    visitService.exitVisit(id, new ExitVisitRequest(exitTime));
+
+    assertThat(visit.getExitTime()).isEqualTo(exitTime);
+    verify(visitRepository).save(visit);
+  }
+
+  // ── editVisit ────────────────────────────────────────────────────────────────
+
+  @Test
+  void editVisit_notFound_throwsBusinessException() {
+    UUID id = UUID.randomUUID();
+    when(visitRepository.findById(id)).thenReturn(Optional.empty());
+
+    EditVisitRequest request =
+        new EditVisitRequest(null, UUID.randomUUID(), UUID.randomUUID(), LocalDateTime.now(), null);
+
+    assertThatThrownBy(() -> visitService.editVisit(id, request))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(
+            ex -> assertThat(((BusinessException) ex).getStatus()).isEqualTo(HttpStatus.NOT_FOUND));
+  }
+
+  @Test
+  void editVisit_assignorNotFound_throwsNotFound() {
+    UUID id = UUID.randomUUID();
+    UUID assignorId = UUID.randomUUID();
+    PersonInRole visitor = personInRole("John", "Smith");
+    Visit visit = visitWithVisitor(visitor);
+
+    when(visitRepository.findById(id)).thenReturn(Optional.of(visit));
+    when(personInRoleRepository.findById(assignorId)).thenReturn(Optional.empty());
+
+    EditVisitRequest request =
+        new EditVisitRequest(null, assignorId, UUID.randomUUID(), LocalDateTime.now(), null);
+
+    assertThatThrownBy(() -> visitService.editVisit(id, request))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(
+            ex -> assertThat(((BusinessException) ex).getStatus()).isEqualTo(HttpStatus.NOT_FOUND));
+  }
+
+  @Test
+  void editVisit_accessPointNotFound_throwsNotFound() {
+    UUID id = UUID.randomUUID();
+    UUID assignorId = UUID.randomUUID();
+    UUID apId = UUID.randomUUID();
+    PersonInRole visitor = personInRole("John", "Smith");
+    Visit visit = visitWithVisitor(visitor);
+
+    when(visitRepository.findById(id)).thenReturn(Optional.of(visit));
+    when(personInRoleRepository.findById(assignorId))
+        .thenReturn(Optional.of(personInRole("Assignor", "User")));
+    when(accessPointRepository.findById(apId)).thenReturn(Optional.empty());
+
+    EditVisitRequest request =
+        new EditVisitRequest(null, assignorId, apId, LocalDateTime.now(), null);
+
+    assertThatThrownBy(() -> visitService.editVisit(id, request))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(
+            ex -> assertThat(((BusinessException) ex).getStatus()).isEqualTo(HttpStatus.NOT_FOUND));
+  }
+
+  @Test
+  void editVisit_nullHost_clearsExistingHost() {
+    UUID id = UUID.randomUUID();
+    UUID assignorId = UUID.randomUUID();
+    UUID apId = UUID.randomUUID();
+    PersonInRole visitor = personInRole("John", "Smith");
+    Visit visit = visitWithVisitor(visitor);
+    visit.setId(id);
+    visit.setHost(personInRole("Old", "Host"));
+
+    when(visitRepository.findById(id)).thenReturn(Optional.of(visit));
+    when(personInRoleRepository.findById(assignorId))
+        .thenReturn(Optional.of(personInRole("Assignor", "User")));
+    when(accessPointRepository.findById(apId)).thenReturn(Optional.of(new AccessPoint()));
+    when(visitRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(keycardInPossessionRepository.findActiveByHolder(visitor)).thenReturn(Optional.empty());
+
+    visitService.editVisit(
+        id, new EditVisitRequest(null, assignorId, apId, LocalDateTime.now(), null));
+
+    assertThat(visit.getHost()).isNull();
+    verify(visitRepository).save(visit);
+  }
+
+  @Test
+  void editVisit_withNewHost_setsHost() {
+    UUID id = UUID.randomUUID();
+    UUID assignorId = UUID.randomUUID();
+    UUID apId = UUID.randomUUID();
+    UUID hostPersonId = UUID.randomUUID();
+    PersonInRole visitor = personInRole("John", "Smith");
+    PersonInRole newHost = personInRole("New", "Host");
+    Person hostPerson = person("New", "Host");
+    Visit visit = visitWithVisitor(visitor);
+    visit.setId(id);
+
+    when(visitRepository.findById(id)).thenReturn(Optional.of(visit));
+    when(personInRoleRepository.findById(assignorId))
+        .thenReturn(Optional.of(personInRole("Assignor", "User")));
+    when(accessPointRepository.findById(apId)).thenReturn(Optional.of(new AccessPoint()));
+    when(personRepository.findById(hostPersonId)).thenReturn(Optional.of(hostPerson));
+    when(personInRoleRepository.findFirstByPersonAndIsActiveTrue(hostPerson))
+        .thenReturn(Optional.of(newHost));
+    when(visitRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(keycardInPossessionRepository.findActiveByHolder(visitor)).thenReturn(Optional.empty());
+
+    visitService.editVisit(
+        id, new EditVisitRequest(hostPersonId, assignorId, apId, LocalDateTime.now(), "Updated"));
+
+    assertThat(visit.getHost()).isEqualTo(newHost);
+    assertThat(visit.getComment()).isEqualTo("Updated");
+  }
+
+  @Test
+  void editVisit_updatesArrivalTime() {
+    UUID id = UUID.randomUUID();
+    UUID assignorId = UUID.randomUUID();
+    UUID apId = UUID.randomUUID();
+    PersonInRole visitor = personInRole("John", "Smith");
+    Visit visit = visitWithVisitor(visitor);
+    visit.setId(id);
+    LocalDateTime newArrival = LocalDateTime.now().minusDays(1);
+
+    when(visitRepository.findById(id)).thenReturn(Optional.of(visit));
+    when(personInRoleRepository.findById(assignorId))
+        .thenReturn(Optional.of(personInRole("Assignor", "User")));
+    when(accessPointRepository.findById(apId)).thenReturn(Optional.of(new AccessPoint()));
+    when(visitRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    when(keycardInPossessionRepository.findActiveByHolder(visitor)).thenReturn(Optional.empty());
+
+    visitService.editVisit(id, new EditVisitRequest(null, assignorId, apId, newArrival, null));
+
+    assertThat(visit.getArrivalTime()).isEqualTo(newArrival);
+  }
+
+  // ── getTimeline ───────────────────────────────────────────────────────────────
+
+  @Test
+  void getTimeline_notFound_throwsBusinessException() {
+    UUID id = UUID.randomUUID();
+    when(visitRepository.findById(id)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> visitService.getTimeline(id))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(
+            ex -> assertThat(((BusinessException) ex).getStatus()).isEqualTo(HttpStatus.NOT_FOUND));
+  }
+
+  @Test
+  void getTimeline_arrivalOnly_returnsOneEntry() {
+    UUID id = UUID.randomUUID();
+    LocalDateTime arrival = LocalDateTime.now().minusHours(2);
+    PersonInRole visitor = personInRole("John", "Smith");
+    Visit visit = visitWithVisitor(visitor);
+    visit.setId(id);
+    visit.setArrivalTime(arrival);
+    visit.setComment("Security meeting");
+
+    when(visitRepository.findById(id)).thenReturn(Optional.of(visit));
+
+    List<VisitTimelineEntry> entries = visitService.getTimeline(id);
+
+    assertThat(entries).hasSize(1);
+    assertThat(entries.get(0).eventType()).isEqualTo("ARRIVAL_REGISTERED");
+    assertThat(entries.get(0).timestamp()).isEqualTo(arrival);
+    assertThat(entries.get(0).details()).isEqualTo("Security meeting");
+  }
+
+  @Test
+  void getTimeline_withDeparture_returnsTwoEntries() {
+    UUID id = UUID.randomUUID();
+    LocalDateTime arrival = LocalDateTime.now().minusHours(2);
+    LocalDateTime exit = LocalDateTime.now().minusMinutes(30);
+    PersonInRole visitor = personInRole("John", "Smith");
+    Visit visit = visitWithVisitor(visitor);
+    visit.setId(id);
+    visit.setArrivalTime(arrival);
+    visit.setExitTime(exit);
+
+    when(visitRepository.findById(id)).thenReturn(Optional.of(visit));
+
+    List<VisitTimelineEntry> entries = visitService.getTimeline(id);
+
+    assertThat(entries).hasSize(2);
+    assertThat(entries.get(0).eventType()).isEqualTo("ARRIVAL_REGISTERED");
+    assertThat(entries.get(1).eventType()).isEqualTo("DEPARTURE_REGISTERED");
+    assertThat(entries.get(1).timestamp()).isEqualTo(exit);
+    assertThat(entries.get(1).details()).isNull();
+  }
+}


### PR DESCRIPTION
We have several issues talking about "visitors", but we don't have this concept. Instead we have a "visit" and there we have people who are people_in_role. So instead of /visitors api endpoint, I'm doing /visits endpoint. There actually already was a createVisit endpoint there and I didn't want to change it outright, but some notes about it that might limit us, but might be ok as well:

* it takes a personId that must already exist in the DB - might be fine, but we have not actually talked this workflow through really. What happens when a person comes who is not in our DB already?
* hostPersonInRoleId is a PersonInRole UUID, not the Person UUID - again, might be ok. Depends if we have this info available at the endpoint use time. I don't yet understand the flow from frontend to backend.
* I don't understand what data should each response really return - so these might be responses with too much information, but I tried my best approximation

A bunch of tests added.
```
./mvnw test -Dtest="VisitServiceTest,VisitControllerTest" 2>&1 | grep -E "(Tests run|BUILD|FAIL|ERROR)"
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.164 s -- in com.caffeine.acs_backend.service.VisitServiceTest
[INFO] Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.190 s -- in com.caffeine.acs_backend.controller.VisitControllerTest
[INFO] Tests run: 43, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS


VisitServiceTest.java — 14 Mockito unit tests

Group	Tests
getVisit	notFound → 404, found with no host/card, found with host, found with active card
exitVisit	notFound → 404, alreadyExited → 409 (no save), success sets exit time
editVisit	notFound → 404, assignor notFound → 404, accessPoint notFound → 404, null host clears existing, new host is set, arrival time is updated
getTimeline	notFound → 404, arrival only (1 entry), arrival + departure (2 entries)

VisitControllerTest.java — 26 @WebMvcTest tests

Endpoint	Tests
GET /api/visits	RECEPTIONIST 200 + JSON check, ADMIN 200, VISITOR 403, unauthenticated 401, status filter passed through
GET /api/visits/{id}	RECEPTIONIST 200 + JSON check, VISITOR 403, unauthenticated 401, 404
POST /api/visits	RECEPTIONIST 201 + JSON check, SECURITY_CHIEF 201, VISITOR 403, missing fields 400
PUT /{id}/exit	RECEPTIONIST 200, ADMIN 200, VISITOR 403, already exited 409, missing exitTime 400
PUT /{id}/edit	ADMIN 200, SECURITY_CHIEF 200, RECEPTIONIST 403, not found 404, missing fields 400
GET /{id}/timeline	RECEPTIONIST 200 + JSON check, VISITOR 403, unauthenticated 401, not found 404
Note on POST /api/visits: because it uses @AuthenticationPrincipal User currentUser (our entity User), those tests use .with(user(entityUser(...))) instead of @WithMockUser to inject the correct principal type.
```

Another note - I added docs/api/ with some notes about the endpoints. It has details about the role based access that might be useful in addition to Swagger doc? Or if not, then let me know and I'll remove it as useless. Seemed a good idea to me at the time.


Some manual testing with curl also to show what it looks like
```
* ── 0. Login and Set up common variables first: ──────────────────
TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"admin@dev.local","password":"password"}' \
  | jq -r '.accessToken')

echo "Token: $TOKEN"

BASE="http://localhost:8080/api"

PERSON_ID="a8000000-0000-0000-0000-000000000007"   # Freddie Mercury's person.id
KEYCARD_ID="a7000000-0000-0000-0000-000000000008"  # an available keycard.id
ACCESS_POINT_ID="a6000000-0000-0000-0000-000000000002"
ASSIGNOR_PIR_ID="ab000000-0000-0000-0000-000000000001" # admin's PersonInRole.id

1. Register the visit — Freddie Mercury arrives with a keycard:

curl -s -X POST "$BASE/visits" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d "{
    \"personId\":      \"$PERSON_ID\",
    \"accessPointId\": \"$ACCESS_POINT_ID\",
    \"keycardId\":     \"$KEYCARD_ID\",
    \"comment\":       \"ready Freddy\",
    \"arrivalTime\":   \"2026-04-12T12:00:00\"
  }" | jq .

# Save the visit ID from the response:
VISIT_ID="80b60b0d-5fc1-47a3-91fc-f78e606a2428"

2. lets then use PUT /api/visits/{visitId}/edit to change comment into "right said Fred"
curl -s -X PUT "$BASE/visits/$VISIT_ID/edit" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d "{
    \"assignorId\":    \"$ASSIGNOR_PIR_ID\",
    \"accessPointId\": \"$ACCESS_POINT_ID\",
    \"entryTime\":     \"2026-04-12T01:00:00\",
    \"comment\":       \"right said Fred\"
  }" | jq .

Response:
{
  "visitId": "80b60b0d-5fc1-47a3-91fc-f78e606a2428",
  "firstName": "Freddie",
  "lastName": "Mercury",
  "personalIdCode": null,
  "organization": "NATO",
  "department": null,
  "hostName": null,
  "visitReason": "right said Fred",
  "cardId": "a7000000-0000-0000-0000-000000000008"
}

3. let's search the vists by visitor first name Freddy
curl -s "$BASE/visits?search=Freddie" \
  -H "Authorization: Bearer $TOKEN" | jq .


4. let's search by dateFrom dateTo +- 6h today
curl -s "$BASE/visits?dateFrom=2026-04-12T00:00:00&dateTo=2026-04-12T18:00:00" \
  -H "Authorization: Bearer $TOKEN" | jq .

5. GET /api/visits/{visitId} of the specific visit details
curl -s "$BASE/visits/$VISIT_ID" \
  -H "Authorization: Bearer $TOKEN" | jq .

Response:
{
  "visitId": "80b60b0d-5fc1-47a3-91fc-f78e606a2428",
  "firstName": "Freddie",
  "lastName": "Mercury",
  "personalIdCode": null,
  "organization": "NATO",
  "department": null,
  "hostName": null,
  "visitReason": "right said Fred",
  "cardId": "a7000000-0000-0000-0000-000000000008"
}

6. and end the visit PUT /api/visits/{visitId}/exit
curl -s -X PUT "$BASE/visits/$VISIT_ID/exit" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d "{
    \"exitTime\": \"2026-04-12T15:30:00\"
  }" | jq .

Response:
{
  "visitId": "80b60b0d-5fc1-47a3-91fc-f78e606a2428",
  "firstName": "Freddie",
  "lastName": "Mercury",
  "personalIdCode": null,
  "organization": "NATO",
  "department": null,
  "hostName": null,
  "visitReason": "right said Fred",
  "cardId": "a7000000-0000-0000-0000-000000000008"
}


7. finally showing the whole timeline with GET /api/visits/{visitId}/timeline
curl -s "$BASE/visits/$VISIT_ID/timeline" \
  -H "Authorization: Bearer $TOKEN" | jq .

Response:
[
  {
    "timestamp": "2026-04-12T01:00:00",
    "eventType": "ARRIVAL_REGISTERED",
    "details": "right said Fred"
  },
  {
    "timestamp": "2026-04-12T15:30:00",
    "eventType": "DEPARTURE_REGISTERED",
    "details": null
  }
]
```