### PR TITLE
bug/46 implement CORS allowed origin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ SPRING_JPA_DDL_AUTO=validate
 # Liquibase contexts (comma-separated). Use "dev" to load seed data. Leave empty in production.
 LIQUIBASE_CONTEXTS=dev
 
+# CORS — comma-separated list of allowed frontend origins
+CORS_ALLOWED_ORIGINS=https://your-frontend.example.com
+
 # JWT — generate with: openssl rand -base64 32
 JWT_SECRET=your-base64-encoded-secret-here
 # JWT_EXPIRATION=7200000  # optional, access token lifetime, default 2h in ms

--- a/src/main/java/com/caffeine/acs_backend/security/SecurityConfig.java
+++ b/src/main/java/com/caffeine/acs_backend/security/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.caffeine.acs_backend.security;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -14,12 +16,18 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+  @Value("${cors.allowed-origins}")
+  private List<String> allowedOrigins;
 
   private final JwtAuthFilter jwtAuthFilter;
   private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
@@ -68,5 +76,17 @@ public class SecurityConfig {
   @Bean
   public PasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration config = new CorsConfiguration();
+    config.setAllowedOrigins(allowedOrigins);
+    config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+    config.setAllowedHeaders(List.of("*"));
+    config.setAllowCredentials(true);
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", config);
+    return source;
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,6 +24,9 @@ jwt.refresh-expiration=${JWT_REFRESH_EXPIRATION:604800000}
 management.endpoints.web.base-path=/
 management.endpoint.health.show-details=always
 
+# ===== CORS =====
+cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:3000}
+
 # ===== Mail =====
 spring.mail.host=${MAIL_HOST:smtp.gmail.com}
 spring.mail.port=${MAIL_PORT:587}

--- a/src/test/java/com/caffeine/acs_backend/security/CorsIntegrationTest.java
+++ b/src/test/java/com/caffeine/acs_backend/security/CorsIntegrationTest.java
@@ -1,0 +1,83 @@
+package com.caffeine.acs_backend.security;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class CorsIntegrationTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  private static final String ALLOWED_ORIGIN = "http://localhost:3000";
+  private static final String DISALLOWED_ORIGIN = "http://evil.example.com";
+
+  // ── Preflight (OPTIONS) ───────────────────────────────────────────────────────
+
+  @Test
+  void preflight_allowedOrigin_returns200WithCorsHeaders() throws Exception {
+    mockMvc
+        .perform(
+            options("/api/auth/login")
+                .header("Origin", ALLOWED_ORIGIN)
+                .header("Access-Control-Request-Method", "POST")
+                .header("Access-Control-Request-Headers", "Content-Type, Authorization"))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Access-Control-Allow-Origin", ALLOWED_ORIGIN))
+        .andExpect(header().exists("Access-Control-Allow-Methods"))
+        .andExpect(header().exists("Access-Control-Allow-Headers"));
+  }
+
+  @Test
+  void preflight_disallowedOrigin_returnsNoCorsHeaders() throws Exception {
+    mockMvc
+        .perform(
+            options("/api/auth/login")
+                .header("Origin", DISALLOWED_ORIGIN)
+                .header("Access-Control-Request-Method", "POST"))
+        .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+  }
+
+  @Test
+  void preflight_allowedOrigin_allowsCredentials() throws Exception {
+    mockMvc
+        .perform(
+            options("/api/auth/login")
+                .header("Origin", ALLOWED_ORIGIN)
+                .header("Access-Control-Request-Method", "POST"))
+        .andExpect(header().string("Access-Control-Allow-Credentials", "true"));
+  }
+
+  // ── Actual requests ───────────────────────────────────────────────────────────
+
+  @Test
+  void actualRequest_allowedOrigin_respondsWithCorsHeader() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/auth/login")
+                .header("Origin", ALLOWED_ORIGIN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"nobody@example.com\",\"password\":\"wrong\"}"))
+        .andExpect(header().string("Access-Control-Allow-Origin", ALLOWED_ORIGIN));
+  }
+
+  @Test
+  void actualRequest_disallowedOrigin_returnsNoCorsHeader() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/auth/login")
+                .header("Origin", DISALLOWED_ORIGIN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"nobody@example.com\",\"password\":\"wrong\"}"))
+        .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+  }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -18,3 +18,5 @@ jwt.refresh-expiration=172800000
 # No emails are actually sent; the service swallows send errors gracefully.
 spring.mail.host=localhost
 spring.mail.port=25
+
+cors.allowed-origins=http://localhost:3000


### PR DESCRIPTION
All 116 tests pass. Here's a summary of all the changes:

* application.properties	cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:3000} — env var with localhost:3000 as fallback
* .env.example	CORS_ALLOWED_ORIGINS=https://your-frontend.example.com as the template
* test/application.properties	cors.allowed-origins=http://localhost:3000 so @WebMvcTest slices can resolve the property

To allow multiple origins in production (e.g. a staging and prod URL), the property accepts a comma-separated list:
CORS_ALLOWED_ORIGINS=https://app.example.com,https://staging.example.com