### PR TITLE
Feat: Edit Visit

### DIFF
--- a/docs/api/visit-endpoints.md
+++ b/docs/api/visit-endpoints.md
@@ -9,12 +9,13 @@ All endpoints require a valid Bearer token (`Authorization: Bearer <token>`).
 ## Endpoints
 
 ### `GET /api/visits`
-**List visits (paginated)**
+
+#### List Visits (Paginated)
 
 Query parameters: `search`, `status` (`planned` | `in_building` | `departed` | `expired`), `dateFrom`, `dateTo`, `page`, `size`
 
 | Role | Access |
-|---|---|
+| --- | --- |
 | ADMIN | allowed |
 | SECURITY_CHIEF | allowed |
 | RECEPTIONIST | allowed |
@@ -23,12 +24,13 @@ Query parameters: `search`, `status` (`planned` | `in_building` | `departed` | `
 ---
 
 ### `GET /api/visits/{visitId}`
-**Get visit details**
+
+#### Get Visit Details
 
 Returns visitor name, personal ID code, organization, department, host name, comment, and assigned card ID.
 
 | Role | Access |
-|---|---|
+| --- | --- |
 | ADMIN | allowed |
 | SECURITY_CHIEF | allowed |
 | RECEPTIONIST | allowed |
@@ -37,14 +39,15 @@ Returns visitor name, personal ID code, organization, department, host name, com
 ---
 
 ### `POST /api/visits`
-**Record a new visit**
+
+#### Record a New Visit
 
 Body: `personId`, `accessPointId`, `keycardId` (optional), `hostPersonInRoleId` (optional), `comment`, `arrivalTime`. The authenticated user is used as the assignor.
 
 Returns full visitor details plus keycard assignment info.
 
 | Role | Access |
-|---|---|
+| --- | --- |
 | ADMIN | allowed |
 | SECURITY_CHIEF | allowed |
 | RECEPTIONIST | allowed |
@@ -53,12 +56,13 @@ Returns full visitor details plus keycard assignment info.
 ---
 
 ### `PUT /api/visits/{visitId}/exit`
-**Record visitor departure**
+
+#### Record Visitor Departure
 
 Body: `exitTime`. Fails with 409 if the visit already has an exit time.
 
 | Role | Access |
-|---|---|
+| --- | --- |
 | ADMIN | allowed |
 | SECURITY_CHIEF | allowed |
 | RECEPTIONIST | allowed |
@@ -67,12 +71,27 @@ Body: `exitTime`. Fails with 409 if the visit already has an exit time.
 ---
 
 ### `PUT /api/visits/{visitId}/edit`
-**Edit visit details**
 
-Body: `hostId`, `assignorId`, `accessPointId`, `entryTime`, `comment`. Restricted to privileged roles only.
+#### Edit Visit Details
+
+Body: `hostId`, `assignorId`, `accessPointId`, `entryTime`, `comment`.
+
+Behavior:
+
+- `hostId = null` clears the host
+- `hostId` must reference an existing person who has an active `PersonInRole`
+- `assignorId` must reference an existing active `PersonInRole`
+- `accessPointId` must reference an existing access point
+- `entryTime` is required
+- `comment` may be `null` or empty, but must not exceed 1024 characters
+- returns `404` when the visit, host, assignor, or access point does not exist
+- returns `409` when `entryTime` is later than an already recorded `exitTime`
+- updates and persists host, assignor, access point, entry time, and comment
+
+Restricted to privileged roles only.
 
 | Role | Access |
-|---|---|
+| --- | --- |
 | ADMIN | allowed |
 | SECURITY_CHIEF | allowed |
 | RECEPTIONIST | denied (403) |
@@ -81,12 +100,15 @@ Body: `hostId`, `assignorId`, `accessPointId`, `entryTime`, `comment`. Restricte
 ---
 
 ### `GET /api/visits/{visitId}/timeline`
-**Get visit audit timeline**
 
-Returns an ordered list of events (`ARRIVAL_REGISTERED`, `DEPARTURE_REGISTERED`) with timestamps and details.
+#### Get Visit Audit Timeline
+
+Returns an ordered list of persisted visit events. The current implementation exposes
+`ARRIVAL_REGISTERED` and `DEPARTURE_REGISTERED` based on stored visit timestamps.
+Editing a visit does not currently create a separate persisted timeline event.
 
 | Role | Access |
-|---|---|
+| --- | --- |
 | ADMIN | allowed |
 | SECURITY_CHIEF | allowed |
 | RECEPTIONIST | allowed |
@@ -97,7 +119,7 @@ Returns an ordered list of events (`ARRIVAL_REGISTERED`, `DEPARTURE_REGISTERED`)
 ## Role Summary
 
 | Endpoint | ADMIN | SECURITY_CHIEF | RECEPTIONIST | VISITOR |
-|---|:---:|:---:|:---:|:---:|
+| --- | :---: | :---: | :---: | :---: |
 | `GET /api/visits` | yes | yes | yes | no |
 | `GET /api/visits/{visitId}` | yes | yes | yes | no |
 | `POST /api/visits` | yes | yes | yes | no |

--- a/src/main/java/com/caffeine/acs_backend/controller/VisitController.java
+++ b/src/main/java/com/caffeine/acs_backend/controller/VisitController.java
@@ -99,12 +99,16 @@ public class VisitController {
   @Operation(
       summary = "Edit visit details",
       description =
-          "Updates the entry time, host, and comment on an existing visit."
+          "Updates the host, assignor, access point, entry time, and comment on an existing visit."
+              + " Sending hostId as null clears the host."
               + " Accessible by Admin and Security Chief only.")
   @ApiResponse(responseCode = "200", description = "Visit updated")
   @ApiResponse(
       responseCode = "404",
       description = "Visit, assignor, access point, or host not found")
+  @ApiResponse(
+      responseCode = "409",
+      description = "Business rule violation, for example entry time after recorded exit time")
   @ApiResponse(responseCode = "401", description = "Unauthorized")
   @ApiResponse(responseCode = "403", description = "Forbidden")
   @PutMapping("/{visitId}/edit")

--- a/src/main/java/com/caffeine/acs_backend/service/VisitService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/VisitService.java
@@ -108,35 +108,14 @@ public class VisitService {
   @Transactional
   public VisitDetailResponse editVisit(UUID visitId, EditVisitRequest request) {
     Visit visit = findVisitOrThrow(visitId);
+    validateEditedEntryTime(visit, request.entryTime());
 
-    // Resolve assignor and access point for audit trail
-    findPersonInRoleOrThrow(request.assignorId());
-    findAccessPointOrThrow(request.accessPointId());
+    PersonInRole assignor = findActivePersonInRoleOrThrow(request.assignorId(), "Assignor");
+    AccessPoint accessPoint = findAccessPointOrThrow(request.accessPointId());
 
-    // Update host — null clears it, non-null sets a new one
-    if (request.hostId() != null) {
-      Person hostPerson =
-          personRepository
-              .findById(request.hostId())
-              .orElseThrow(
-                  () ->
-                      new BusinessException(
-                          "Host person not found: " + request.hostId(),
-                          ErrorCode.RESOURCE_NOT_FOUND,
-                          HttpStatus.NOT_FOUND));
-      PersonInRole host =
-          personInRoleRepository
-              .findFirstByPersonAndIsActiveTrue(hostPerson)
-              .orElseThrow(
-                  () ->
-                      new BusinessException(
-                          "Host has no active role assignment: " + request.hostId(),
-                          ErrorCode.RESOURCE_NOT_FOUND,
-                          HttpStatus.NOT_FOUND));
-      visit.setHost(host);
-    } else {
-      visit.setHost(null);
-    }
+    visit.setAssignor(assignor);
+    visit.setAccessPoint(accessPoint);
+    visit.setHost(resolveHostOrNull(request.hostId()));
 
     visit.setArrivalTime(request.entryTime());
     visit.setComment(request.comment());
@@ -300,6 +279,17 @@ public class VisitService {
                     HttpStatus.NOT_FOUND));
   }
 
+  private PersonInRole findActivePersonInRoleOrThrow(UUID personInRoleId, String roleLabel) {
+    PersonInRole personInRole = findPersonInRoleOrThrow(personInRoleId);
+    if (!personInRole.isActive()) {
+      throw new BusinessException(
+          roleLabel + " must reference an active role assignment: " + personInRoleId,
+          ErrorCode.RESOURCE_NOT_FOUND,
+          HttpStatus.NOT_FOUND);
+    }
+    return personInRole;
+  }
+
   private AccessPoint findAccessPointOrThrow(UUID accessPointId) {
     return accessPointRepository
         .findById(accessPointId)
@@ -309,6 +299,40 @@ public class VisitService {
                     "Access point not found: " + accessPointId,
                     ErrorCode.RESOURCE_NOT_FOUND,
                     HttpStatus.NOT_FOUND));
+  }
+
+  private PersonInRole resolveHostOrNull(UUID hostId) {
+    if (hostId == null) {
+      return null;
+    }
+
+    Person hostPerson =
+        personRepository
+            .findById(hostId)
+            .orElseThrow(
+                () ->
+                    new BusinessException(
+                        "Host person not found: " + hostId,
+                        ErrorCode.RESOURCE_NOT_FOUND,
+                        HttpStatus.NOT_FOUND));
+
+    return personInRoleRepository
+        .findFirstByPersonAndIsActiveTrue(hostPerson)
+        .orElseThrow(
+            () ->
+                new BusinessException(
+                    "Host has no active role assignment: " + hostId,
+                    ErrorCode.RESOURCE_NOT_FOUND,
+                    HttpStatus.NOT_FOUND));
+  }
+
+  private void validateEditedEntryTime(Visit visit, LocalDateTime newEntryTime) {
+    if (visit.getExitTime() != null && newEntryTime.isAfter(visit.getExitTime())) {
+      throw new BusinessException(
+          "Entry time cannot be later than the recorded exit time",
+          ErrorCode.BUSINESS_RULE_VIOLATION,
+          HttpStatus.CONFLICT);
+    }
   }
 
   private Role findVisitorRole() {

--- a/src/test/java/com/caffeine/acs_backend/controller/VisitControllerTest.java
+++ b/src/test/java/com/caffeine/acs_backend/controller/VisitControllerTest.java
@@ -389,15 +389,12 @@ class VisitControllerTest {
   @Test
   @WithMockUser(roles = "VISITOR")
   void editVisit_visitor_returns403() throws Exception {
-    EditVisitRequest request =
-        new EditVisitRequest(null, UUID.randomUUID(), UUID.randomUUID(), LocalDateTime.now(), null);
-
     mockMvc
         .perform(
             put("/api/visits/{id}/edit", VISIT_ID)
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
+                .content("{}"))
         .andExpect(status().isForbidden());
   }
 

--- a/src/test/java/com/caffeine/acs_backend/controller/VisitControllerTest.java
+++ b/src/test/java/com/caffeine/acs_backend/controller/VisitControllerTest.java
@@ -30,6 +30,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -371,30 +373,19 @@ class VisitControllerTest {
         .andExpect(status().isOk());
   }
 
-  @Test
-  @WithMockUser(roles = "RECEPTIONIST")
-  void editVisit_receptionist_returns403() throws Exception {
+  @ParameterizedTest
+  @ValueSource(strings = {"RECEPTIONIST", "VISITOR"})
+  void editVisit_forbiddenRoles_return403(String role) throws Exception {
     EditVisitRequest request =
         new EditVisitRequest(null, UUID.randomUUID(), UUID.randomUUID(), LocalDateTime.now(), null);
 
     mockMvc
         .perform(
             put("/api/visits/{id}/edit", VISIT_ID)
+                .with(user(role.toLowerCase()).roles(role))
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
-        .andExpect(status().isForbidden());
-  }
-
-  @Test
-  @WithMockUser(roles = "VISITOR")
-  void editVisit_visitor_returns403() throws Exception {
-    mockMvc
-        .perform(
-            put("/api/visits/{id}/edit", VISIT_ID)
-                .with(csrf())
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{}"))
         .andExpect(status().isForbidden());
   }
 

--- a/src/test/java/com/caffeine/acs_backend/controller/VisitControllerTest.java
+++ b/src/test/java/com/caffeine/acs_backend/controller/VisitControllerTest.java
@@ -387,6 +387,21 @@ class VisitControllerTest {
   }
 
   @Test
+  @WithMockUser(roles = "VISITOR")
+  void editVisit_visitor_returns403() throws Exception {
+    EditVisitRequest request =
+        new EditVisitRequest(null, UUID.randomUUID(), UUID.randomUUID(), LocalDateTime.now(), null);
+
+    mockMvc
+        .perform(
+            put("/api/visits/{id}/edit", VISIT_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
   @WithMockUser(roles = "ADMIN")
   void editVisit_notFound_returns404() throws Exception {
     EditVisitRequest request =
@@ -403,6 +418,27 @@ class VisitControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockUser(roles = "ADMIN")
+  void editVisit_entryTimeConflict_returns409() throws Exception {
+    EditVisitRequest request =
+        new EditVisitRequest(null, UUID.randomUUID(), UUID.randomUUID(), LocalDateTime.now(), null);
+    when(visitService.editVisit(eq(VISIT_ID), any()))
+        .thenThrow(
+            new BusinessException(
+                "Entry time cannot be later than the recorded exit time",
+                ErrorCode.BUSINESS_RULE_VIOLATION,
+                HttpStatus.CONFLICT));
+
+    mockMvc
+        .perform(
+            put("/api/visits/{id}/edit", VISIT_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+        .andExpect(status().isConflict());
   }
 
   @Test

--- a/src/test/java/com/caffeine/acs_backend/service/VisitServiceTest.java
+++ b/src/test/java/com/caffeine/acs_backend/service/VisitServiceTest.java
@@ -318,8 +318,7 @@ class VisitServiceTest {
     VisitDetailResponse response =
         visitService.editVisit(
             id,
-            new EditVisitRequest(
-                hostPersonId, assignorId, apId, LocalDateTime.now(), "Updated"));
+            new EditVisitRequest(hostPersonId, assignorId, apId, LocalDateTime.now(), "Updated"));
 
     assertThat(visit.getHost()).isEqualTo(newHost);
     assertThat(visit.getComment()).isEqualTo("Updated");

--- a/src/test/java/com/caffeine/acs_backend/service/VisitServiceTest.java
+++ b/src/test/java/com/caffeine/acs_backend/service/VisitServiceTest.java
@@ -340,13 +340,10 @@ class VisitServiceTest {
         .thenReturn(Optional.of(personInRole("Assignor", "User")));
     when(accessPointRepository.findById(apId)).thenReturn(Optional.of(new AccessPoint()));
     when(personRepository.findById(hostPersonId)).thenReturn(Optional.empty());
+    EditVisitRequest request =
+        new EditVisitRequest(hostPersonId, assignorId, apId, LocalDateTime.now(), "Updated");
 
-    assertThatThrownBy(
-            () ->
-                visitService.editVisit(
-                    id,
-                    new EditVisitRequest(
-                        hostPersonId, assignorId, apId, LocalDateTime.now(), "Updated")))
+    assertThatThrownBy(() -> visitService.editVisit(id, request))
         .isInstanceOf(BusinessException.class)
         .satisfies(
             ex -> assertThat(((BusinessException) ex).getStatus()).isEqualTo(HttpStatus.NOT_FOUND));
@@ -369,13 +366,10 @@ class VisitServiceTest {
     when(personRepository.findById(hostPersonId)).thenReturn(Optional.of(hostPerson));
     when(personInRoleRepository.findFirstByPersonAndIsActiveTrue(hostPerson))
         .thenReturn(Optional.empty());
+    EditVisitRequest request =
+        new EditVisitRequest(hostPersonId, assignorId, apId, LocalDateTime.now(), "Updated");
 
-    assertThatThrownBy(
-            () ->
-                visitService.editVisit(
-                    id,
-                    new EditVisitRequest(
-                        hostPersonId, assignorId, apId, LocalDateTime.now(), "Updated")))
+    assertThatThrownBy(() -> visitService.editVisit(id, request))
         .isInstanceOf(BusinessException.class)
         .satisfies(
             ex -> assertThat(((BusinessException) ex).getStatus()).isEqualTo(HttpStatus.NOT_FOUND));
@@ -415,15 +409,12 @@ class VisitServiceTest {
     Visit visit = visitWithVisitor(visitor);
     LocalDateTime exitTime = LocalDateTime.now().minusMinutes(15);
     visit.setExitTime(exitTime);
+    EditVisitRequest request =
+        new EditVisitRequest(null, assignorId, apId, exitTime.plusMinutes(1), "Updated");
 
     when(visitRepository.findById(id)).thenReturn(Optional.of(visit));
 
-    assertThatThrownBy(
-            () ->
-                visitService.editVisit(
-                    id,
-                    new EditVisitRequest(
-                        null, assignorId, apId, exitTime.plusMinutes(1), "Updated")))
+    assertThatThrownBy(() -> visitService.editVisit(id, request))
         .isInstanceOf(BusinessException.class)
         .satisfies(
             ex -> {

--- a/src/test/java/com/caffeine/acs_backend/service/VisitServiceTest.java
+++ b/src/test/java/com/caffeine/acs_backend/service/VisitServiceTest.java
@@ -10,6 +10,7 @@ import com.caffeine.acs_backend.dto.visit.ExitVisitRequest;
 import com.caffeine.acs_backend.dto.visit.VisitDetailResponse;
 import com.caffeine.acs_backend.dto.visit.VisitTimelineEntry;
 import com.caffeine.acs_backend.entity.*;
+import com.caffeine.acs_backend.enums.errorcode.ErrorCode;
 import com.caffeine.acs_backend.exception.BusinessException;
 import com.caffeine.acs_backend.repository.*;
 import java.time.LocalDateTime;
@@ -220,6 +221,31 @@ class VisitServiceTest {
   }
 
   @Test
+  void editVisit_inactiveAssignor_throwsNotFound() {
+    UUID id = UUID.randomUUID();
+    UUID assignorId = UUID.randomUUID();
+    PersonInRole visitor = personInRole("John", "Smith");
+    PersonInRole inactiveAssignor = personInRole("Inactive", "Assignor");
+    inactiveAssignor.setActive(false);
+    Visit visit = visitWithVisitor(visitor);
+
+    when(visitRepository.findById(id)).thenReturn(Optional.of(visit));
+    when(personInRoleRepository.findById(assignorId)).thenReturn(Optional.of(inactiveAssignor));
+
+    EditVisitRequest request =
+        new EditVisitRequest(null, assignorId, UUID.randomUUID(), LocalDateTime.now(), null);
+
+    assertThatThrownBy(() -> visitService.editVisit(id, request))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(
+            ex -> {
+              BusinessException businessException = (BusinessException) ex;
+              assertThat(businessException.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
+              assertThat(businessException.getErrorCode()).isEqualTo(ErrorCode.RESOURCE_NOT_FOUND);
+            });
+  }
+
+  @Test
   void editVisit_accessPointNotFound_throwsNotFound() {
     UUID id = UUID.randomUUID();
     UUID assignorId = UUID.randomUUID();
@@ -262,6 +288,8 @@ class VisitServiceTest {
         id, new EditVisitRequest(null, assignorId, apId, LocalDateTime.now(), null));
 
     assertThat(visit.getHost()).isNull();
+    assertThat(visit.getAssignor()).isNotNull();
+    assertThat(visit.getAccessPoint()).isNotNull();
     verify(visitRepository).save(visit);
   }
 
@@ -287,11 +315,71 @@ class VisitServiceTest {
     when(visitRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
     when(keycardInPossessionRepository.findActiveByHolder(visitor)).thenReturn(Optional.empty());
 
-    visitService.editVisit(
-        id, new EditVisitRequest(hostPersonId, assignorId, apId, LocalDateTime.now(), "Updated"));
+    VisitDetailResponse response =
+        visitService.editVisit(
+            id,
+            new EditVisitRequest(
+                hostPersonId, assignorId, apId, LocalDateTime.now(), "Updated"));
 
     assertThat(visit.getHost()).isEqualTo(newHost);
     assertThat(visit.getComment()).isEqualTo("Updated");
+    assertThat(response.hostName()).isEqualTo("New Host");
+    assertThat(response.visitReason()).isEqualTo("Updated");
+  }
+
+  @Test
+  void editVisit_hostPersonNotFound_throwsNotFound() {
+    UUID id = UUID.randomUUID();
+    UUID assignorId = UUID.randomUUID();
+    UUID apId = UUID.randomUUID();
+    UUID hostPersonId = UUID.randomUUID();
+    PersonInRole visitor = personInRole("John", "Smith");
+    Visit visit = visitWithVisitor(visitor);
+
+    when(visitRepository.findById(id)).thenReturn(Optional.of(visit));
+    when(personInRoleRepository.findById(assignorId))
+        .thenReturn(Optional.of(personInRole("Assignor", "User")));
+    when(accessPointRepository.findById(apId)).thenReturn(Optional.of(new AccessPoint()));
+    when(personRepository.findById(hostPersonId)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                visitService.editVisit(
+                    id,
+                    new EditVisitRequest(
+                        hostPersonId, assignorId, apId, LocalDateTime.now(), "Updated")))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(
+            ex -> assertThat(((BusinessException) ex).getStatus()).isEqualTo(HttpStatus.NOT_FOUND));
+  }
+
+  @Test
+  void editVisit_hostWithoutActiveRole_throwsNotFound() {
+    UUID id = UUID.randomUUID();
+    UUID assignorId = UUID.randomUUID();
+    UUID apId = UUID.randomUUID();
+    UUID hostPersonId = UUID.randomUUID();
+    PersonInRole visitor = personInRole("John", "Smith");
+    Person hostPerson = person("New", "Host");
+    Visit visit = visitWithVisitor(visitor);
+
+    when(visitRepository.findById(id)).thenReturn(Optional.of(visit));
+    when(personInRoleRepository.findById(assignorId))
+        .thenReturn(Optional.of(personInRole("Assignor", "User")));
+    when(accessPointRepository.findById(apId)).thenReturn(Optional.of(new AccessPoint()));
+    when(personRepository.findById(hostPersonId)).thenReturn(Optional.of(hostPerson));
+    when(personInRoleRepository.findFirstByPersonAndIsActiveTrue(hostPerson))
+        .thenReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () ->
+                visitService.editVisit(
+                    id,
+                    new EditVisitRequest(
+                        hostPersonId, assignorId, apId, LocalDateTime.now(), "Updated")))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(
+            ex -> assertThat(((BusinessException) ex).getStatus()).isEqualTo(HttpStatus.NOT_FOUND));
   }
 
   @Test
@@ -303,17 +391,52 @@ class VisitServiceTest {
     Visit visit = visitWithVisitor(visitor);
     visit.setId(id);
     LocalDateTime newArrival = LocalDateTime.now().minusDays(1);
+    PersonInRole assignor = personInRole("Assignor", "User");
+    AccessPoint accessPoint = new AccessPoint();
 
     when(visitRepository.findById(id)).thenReturn(Optional.of(visit));
-    when(personInRoleRepository.findById(assignorId))
-        .thenReturn(Optional.of(personInRole("Assignor", "User")));
-    when(accessPointRepository.findById(apId)).thenReturn(Optional.of(new AccessPoint()));
+    when(personInRoleRepository.findById(assignorId)).thenReturn(Optional.of(assignor));
+    when(accessPointRepository.findById(apId)).thenReturn(Optional.of(accessPoint));
     when(visitRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
     when(keycardInPossessionRepository.findActiveByHolder(visitor)).thenReturn(Optional.empty());
 
     visitService.editVisit(id, new EditVisitRequest(null, assignorId, apId, newArrival, null));
 
     assertThat(visit.getArrivalTime()).isEqualTo(newArrival);
+    assertThat(visit.getAssignor()).isEqualTo(assignor);
+    assertThat(visit.getAccessPoint()).isEqualTo(accessPoint);
+  }
+
+  @Test
+  void editVisit_entryTimeAfterExitTime_throwsConflict() {
+    UUID id = UUID.randomUUID();
+    UUID assignorId = UUID.randomUUID();
+    UUID apId = UUID.randomUUID();
+    PersonInRole visitor = personInRole("John", "Smith");
+    Visit visit = visitWithVisitor(visitor);
+    LocalDateTime exitTime = LocalDateTime.now().minusMinutes(15);
+    visit.setExitTime(exitTime);
+
+    when(visitRepository.findById(id)).thenReturn(Optional.of(visit));
+
+    assertThatThrownBy(
+            () ->
+                visitService.editVisit(
+                    id,
+                    new EditVisitRequest(
+                        null, assignorId, apId, exitTime.plusMinutes(1), "Updated")))
+        .isInstanceOf(BusinessException.class)
+        .satisfies(
+            ex -> {
+              BusinessException businessException = (BusinessException) ex;
+              assertThat(businessException.getStatus()).isEqualTo(HttpStatus.CONFLICT);
+              assertThat(businessException.getErrorCode())
+                  .isEqualTo(ErrorCode.BUSINESS_RULE_VIOLATION);
+            });
+
+    verify(personInRoleRepository, never()).findById(any());
+    verify(accessPointRepository, never()).findById(any());
+    verify(visitRepository, never()).save(any());
   }
 
   // ── getTimeline ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements and clarifies the `PUT /api/visits/{visitId}/edit` flow so that visit edits are consistently validated, persisted, and documented.

## Changes

- update `VisitService.editVisit` to persist `assignor`, `accessPoint`, `host`, `entryTime`, and `comment`
- allow clearing the host with `hostId = null`
- require `assignorId` to reference an active `PersonInRole`
- require `hostId` to reference an existing person with an active `PersonInRole`
- require `accessPointId` to reference an existing access point
- add business-rule validation for `entryTime` so it cannot be later than an existing `exitTime`
- align controller OpenAPI metadata with actual edit behavior
- update API documentation in `docs/api/visit-endpoints.md`
- add controller and service tests for positive and negative edit scenarios

## Behavior

- `ADMIN` and `SECURITY_CHIEF` can edit visits
- `RECEPTIONIST` and `VISITOR` receive `403`
- non-existent visit, host, assignor, or access point returns `404`
- invalid `entryTime` vs `exitTime` returns `409`
- `VisitStatus` is not changed by the edit flow

## Testing

- added service tests for:
  - successful host update
  - clearing host with `null`
  - updating assignor and access point
  - missing host / assignor / access point
  - inactive assignor
  - `entryTime` conflict with existing `exitTime`
- added controller tests for:
  - successful edit as `ADMIN`
  - successful edit as `SECURITY_CHIEF`
  - `403` for `RECEPTIONIST`
  - `403` for `VISITOR`
  - `404` for missing visit
  - `409` for invalid `entryTime`

## Notes

- timeline behavior was documented explicitly: editing a visit does not currently create a separate persisted `VISIT_EDITED` event
- automated test execution was not run in the current shell because `java` / `JAVA_HOME` is not available
