### PR TITLE
Task/59 update GitHub actions to node 24 compatible action versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -25,7 +25,7 @@ jobs:
         run: mvn --no-transfer-progress checkstyle:check
 
       - name: Dockerfile Linting with Hadolint
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf
         with:
           dockerfile: "**/Dockerfile*"
           recursive: true

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -25,18 +25,18 @@ jobs:
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
       - name: Run tests and generate JaCoCo report
         run: mvn -B clean test jacoco:report
       - name: Cache SonarQube packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
## What changed

Updated GitHub Actions workflow dependencies to Node 24-compatible major versions.

- `.github/workflows/lint.yml`
  - `actions/checkout`: `v4` -> `v6`
  - `actions/setup-java`: `v4` -> `v5`
- `.github/workflows/sonar.yml`
  - `actions/checkout`: `v4` -> `v6`
  - `actions/setup-java`: `v4` -> `v5`
  - `actions/cache`: `v4` -> `v5`

Also pinned `hadolint/hadolint-action` in the lint workflow to a full commit SHA to satisfy GitHub Actions dependency pinning guidance.

## Why

GitHub Actions emits a deprecation warning because some JavaScript actions still run on the Node.js 20 action runtime. GitHub will switch JavaScript actions to Node.js 24 by default on June 2, 2026, and remove Node.js 20 from runners on September 16, 2026.

This change keeps workflow behavior the same while moving the referenced actions to Node 24-compatible majors and tightening one third-party action pin.

## Impact

- No application runtime changes
- No intended workflow behavior changes apart from action runtime/dependency updates
- Should remove the Node.js 20 deprecation warning from the affected workflows

## Validation

Local verification was limited in this environment:
- confirmed the workflow diffs are scoped to the requested action version updates
- confirmed the workflow YAML still parses
- Maven checks could not be run locally because no JDK was installed and `JAVA_HOME` was unset in the environment

GitHub Actions should validate:
- lint / formatting / tests
- Sonar analysis
