### PR TITLE
Bug/69 dotmartti keycard lastreturndate future

### DIFF
--- a/src/main/java/com/caffeine/acs_backend/dto/keycard/KeycardDetailResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/keycard/KeycardDetailResponse.java
@@ -6,6 +6,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+
+
 @Schema(description = "Full keycard details")
 public record KeycardDetailResponse(
     @Schema(description = "Unique identifier") UUID id,
@@ -33,6 +35,10 @@ public record KeycardDetailResponse(
       assignedPersonInRoleId = activePossession.getKeycardHolder().getId();
       assignedTime = activePossession.getAssignedTime();
     }
+    LocalDateTime pastReturnTime =
+        lastReturnTime != null && lastReturnTime.isBefore(LocalDateTime.now())
+            ? lastReturnTime
+            : null;
     return new KeycardDetailResponse(
         keycard.getId(),
         keycard.getKeycardNumber(),
@@ -41,6 +47,6 @@ public record KeycardDetailResponse(
         assignedUser,
         assignedPersonInRoleId,
         assignedTime,
-        lastReturnTime);
+        pastReturnTime);
   }
 }

--- a/src/main/java/com/caffeine/acs_backend/dto/keycard/KeycardDetailResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/keycard/KeycardDetailResponse.java
@@ -6,8 +6,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-
-
 @Schema(description = "Full keycard details")
 public record KeycardDetailResponse(
     @Schema(description = "Unique identifier") UUID id,

--- a/src/main/java/com/caffeine/acs_backend/dto/keycard/KeycardListItemResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/keycard/KeycardListItemResponse.java
@@ -20,11 +20,16 @@ public record KeycardListItemResponse(
         LocalDateTime lastReturnTime) {
 
   public static KeycardListItemResponse from(KeycardListView view) {
+    LocalDateTime rawReturnTime = view.getLastReturnTime();
+    LocalDateTime pastReturnTime =
+        rawReturnTime != null && rawReturnTime.isBefore(LocalDateTime.now())
+            ? rawReturnTime
+            : null;
     return new KeycardListItemResponse(
         view.getId(),
         view.getKeycardNumber(),
         view.getStatus(),
         view.getAssignedUser(),
-        view.getLastReturnTime());
+        pastReturnTime);
   }
 }

--- a/src/main/java/com/caffeine/acs_backend/dto/keycard/KeycardListItemResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/keycard/KeycardListItemResponse.java
@@ -22,9 +22,7 @@ public record KeycardListItemResponse(
   public static KeycardListItemResponse from(KeycardListView view) {
     LocalDateTime rawReturnTime = view.getLastReturnTime();
     LocalDateTime pastReturnTime =
-        rawReturnTime != null && rawReturnTime.isBefore(LocalDateTime.now())
-            ? rawReturnTime
-            : null;
+        rawReturnTime != null && rawReturnTime.isBefore(LocalDateTime.now()) ? rawReturnTime : null;
     return new KeycardListItemResponse(
         view.getId(),
         view.getKeycardNumber(),

--- a/src/test/java/com/caffeine/acs_backend/dto/keycard/KeycardResponseTest.java
+++ b/src/test/java/com/caffeine/acs_backend/dto/keycard/KeycardResponseTest.java
@@ -1,0 +1,86 @@
+package com.caffeine.acs_backend.dto.keycard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.caffeine.acs_backend.entity.Keycard;
+import com.caffeine.acs_backend.repository.KeycardListView;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class KeycardResponseTest {
+
+  // ── Helpers ───────────────────────────────────────────────────────────────────
+
+  private Keycard keycard() {
+    Keycard k = Keycard.builder().keycardNumber("KC-0001").isActive(true).build();
+    k.setId(UUID.randomUUID());
+    return k;
+  }
+
+  private KeycardListView listView(LocalDateTime lastReturnTime) {
+    KeycardListView view = mock(KeycardListView.class);
+    when(view.getId()).thenReturn(UUID.randomUUID());
+    when(view.getKeycardNumber()).thenReturn("KC-0001");
+    when(view.getStatus()).thenReturn("AVAILABLE");
+    when(view.getAssignedUser()).thenReturn(null);
+    when(view.getLastReturnTime()).thenReturn(lastReturnTime);
+    return view;
+  }
+
+  // ── KeycardDetailResponse.from — lastReturnTime filtering ─────────────────────
+
+  @Test
+  void detailResponse_pastReturnTime_isPreserved() {
+    LocalDateTime past = LocalDateTime.now().minusHours(1);
+
+    KeycardDetailResponse response = KeycardDetailResponse.from(keycard(), null, past);
+
+    assertThat(response.lastReturnTime()).isEqualTo(past);
+  }
+
+  @Test
+  void detailResponse_futureReturnTime_isNulled() {
+    LocalDateTime future = LocalDateTime.now().plusHours(1);
+
+    KeycardDetailResponse response = KeycardDetailResponse.from(keycard(), null, future);
+
+    assertThat(response.lastReturnTime()).isNull();
+  }
+
+  @Test
+  void detailResponse_nullReturnTime_remainsNull() {
+    KeycardDetailResponse response = KeycardDetailResponse.from(keycard(), null, null);
+
+    assertThat(response.lastReturnTime()).isNull();
+  }
+
+  // ── KeycardListItemResponse.from — lastReturnTime filtering ───────────────────
+
+  @Test
+  void listResponse_pastReturnTime_isPreserved() {
+    LocalDateTime past = LocalDateTime.now().minusDays(1);
+
+    KeycardListItemResponse response = KeycardListItemResponse.from(listView(past));
+
+    assertThat(response.lastReturnTime()).isEqualTo(past);
+  }
+
+  @Test
+  void listResponse_futureReturnTime_isNulled() {
+    LocalDateTime future = LocalDateTime.now().plusDays(1);
+
+    KeycardListItemResponse response = KeycardListItemResponse.from(listView(future));
+
+    assertThat(response.lastReturnTime()).isNull();
+  }
+
+  @Test
+  void listResponse_nullReturnTime_remainsNull() {
+    KeycardListItemResponse response = KeycardListItemResponse.from(listView(null));
+
+    assertThat(response.lastReturnTime()).isNull();
+  }
+}


### PR DESCRIPTION
There was a bug that backend returned future dates from the database about "last returned keycard" - "Viimati tagastatud". If the date is in the future for some reason, then the backend should not return it. It is now fixed.

<img width="1202" height="276" alt="pilt" src="https://github.com/user-attachments/assets/4a10767d-23d3-46c2-ad16-cdd13f7bf271" />

Related to https://github.com/Team-Caffeine-ACS/acs-frontend/pull/77