### PR TITLE
refactor: move past return time validation to KeycardService

### DIFF
--- a/src/main/java/com/caffeine/acs_backend/dto/keycard/KeycardDetailResponse.java
+++ b/src/main/java/com/caffeine/acs_backend/dto/keycard/KeycardDetailResponse.java
@@ -23,20 +23,19 @@ public record KeycardDetailResponse(
         LocalDateTime lastReturnTime) {
 
   public static KeycardDetailResponse from(
-      Keycard keycard, KeycardInPossession activePossession, LocalDateTime lastReturnTime) {
+      Keycard keycard, KeycardInPossession activePossession, LocalDateTime pastReturnTime) {
+
     String assignedUser = null;
     UUID assignedPersonInRoleId = null;
     LocalDateTime assignedTime = null;
+
     if (activePossession != null) {
       var person = activePossession.getKeycardHolder().getPerson();
       assignedUser = person.getGivenName() + " " + person.getSurname();
       assignedPersonInRoleId = activePossession.getKeycardHolder().getId();
       assignedTime = activePossession.getAssignedTime();
     }
-    LocalDateTime pastReturnTime =
-        lastReturnTime != null && !lastReturnTime.isAfter(LocalDateTime.now())
-            ? lastReturnTime
-            : null;
+
     return new KeycardDetailResponse(
         keycard.getId(),
         keycard.getKeycardNumber(),

--- a/src/main/java/com/caffeine/acs_backend/service/KeycardService.java
+++ b/src/main/java/com/caffeine/acs_backend/service/KeycardService.java
@@ -50,15 +50,8 @@ public class KeycardService {
     Keycard keycard = findKeycardOrThrow(id);
     KeycardInPossession active =
         keycardInPossessionRepository.findActiveByKeycard(keycard).orElse(null);
-    LocalDateTime lastReturn = null;
-    if (active == null) {
-      lastReturn =
-          keycardInPossessionRepository.findLatestByKeycard(keycard, PageRequest.of(0, 1)).stream()
-              .findFirst()
-              .map(KeycardInPossession::getReturnTime)
-              .orElse(null);
-    }
-    return KeycardDetailResponse.from(keycard, active, lastReturn);
+    LocalDateTime validatedReturn = (active == null) ? getValidatedPastReturnTime(keycard) : null;
+    return KeycardDetailResponse.from(keycard, active, validatedReturn);
   }
 
   @Transactional
@@ -94,15 +87,8 @@ public class KeycardService {
     keycardRepository.save(keycard);
     KeycardInPossession active =
         keycardInPossessionRepository.findActiveByKeycard(keycard).orElse(null);
-    LocalDateTime lastReturn = null;
-    if (active == null) {
-      lastReturn =
-          keycardInPossessionRepository.findLatestByKeycard(keycard, PageRequest.of(0, 1)).stream()
-              .findFirst()
-              .map(KeycardInPossession::getReturnTime)
-              .orElse(null);
-    }
-    return KeycardDetailResponse.from(keycard, active, lastReturn);
+    LocalDateTime validatedReturn = (active == null) ? getValidatedPastReturnTime(keycard) : null;
+    return KeycardDetailResponse.from(keycard, active, validatedReturn);
   }
 
   @Transactional
@@ -206,5 +192,13 @@ public class KeycardService {
                     "Keycard not found: " + id,
                     ErrorCode.RESOURCE_NOT_FOUND,
                     HttpStatus.NOT_FOUND));
+  }
+
+  private LocalDateTime getValidatedPastReturnTime(Keycard keycard) {
+    return keycardInPossessionRepository.findLatestByKeycard(keycard, PageRequest.of(0, 1)).stream()
+        .findFirst()
+        .map(KeycardInPossession::getReturnTime)
+        .filter(returnTime -> returnTime != null && !returnTime.isAfter(LocalDateTime.now()))
+        .orElse(null);
   }
 }


### PR DESCRIPTION
- Removed business logic and LocalDateTime.now() calls from KeycardDetailResponse.
- Added getValidatedPastReturnTime helper method to KeycardService.
- Cleaned up technical debt and improved DTO testability.

### Description
Currently, the KeycardDetailResponse.from() static factory method contains business logic to validate whether lastReturnTime is in the past. This violates the single responsibility principle of a DTO, which should only be responsible for data carrying and simple mapping.

### Acceptance Criteria

- [x] KeycardDetailResponse contains no business logic or calls to LocalDateTime.now().
- [x] KeycardService correctly calculates the pastReturnTime before passing it to the DTO.
- [x] All unit tests pass, and the race condition buffer is preserved if necessary.

#76